### PR TITLE
CHAIN-1260: improve node type enum to reduce duplicate code

### DIFF
--- a/runner/benchmark/benchmark.go
+++ b/runner/benchmark/benchmark.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/base/base-bench/runner/clients"
 	"github.com/base/base-bench/runner/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
@@ -21,7 +22,7 @@ type TransactionPayload struct {
 
 // Params is the parameters for a single benchmark run.
 type Params struct {
-	NodeType           string
+	NodeType           clients.Client
 	GasLimit           uint64
 	TransactionPayload []TransactionPayload
 	BlockTime          time.Duration
@@ -51,7 +52,11 @@ func NewParamsFromValues(assignments map[ParamType]string, transactionPayloads [
 	for k, v := range assignments {
 		switch k {
 		case ParamTypeNode:
-			params.NodeType = v
+			cl, err := clients.ParseClient(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid client %s", v)
+			}
+			params.NodeType = cl
 		case ParamTypeGasLimit:
 			gasLimit, err := strconv.Atoi(v)
 			if err != nil {

--- a/runner/benchmark/matrix_test.go
+++ b/runner/benchmark/matrix_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/base/base-bench/runner/benchmark"
+	"github.com/base/base-bench/runner/clients"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +28,7 @@ func TestNewMatrixFromConfig(t *testing.T) {
 			},
 			want: benchmark.ParamsMatrix{
 				{
-					NodeType:           "geth",
+					NodeType:           clients.Geth,
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}},
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					BlockTime:          time.Second,
@@ -51,13 +52,13 @@ func TestNewMatrixFromConfig(t *testing.T) {
 			},
 			want: benchmark.ParamsMatrix{
 				{
-					NodeType:           "geth",
+					NodeType:           clients.Geth,
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					BlockTime:          time.Second,
 				},
 				{
-					NodeType:           "reth",
+					NodeType:           clients.Reth,
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					BlockTime:          time.Second,
@@ -85,28 +86,28 @@ func TestNewMatrixFromConfig(t *testing.T) {
 			},
 			want: benchmark.ParamsMatrix{
 				{
-					NodeType:           "geth",
+					NodeType:           clients.Geth,
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					BlockTime:          time.Second,
 					Env:                map[string]string{"TEST_ENV": "0"},
 				},
 				{
-					NodeType:           "reth",
+					NodeType:           clients.Reth,
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					BlockTime:          time.Second,
 					Env:                map[string]string{"TEST_ENV": "0"},
 				},
 				{
-					NodeType:           "geth",
+					NodeType:           clients.Geth,
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					BlockTime:          time.Second,
 					Env:                map[string]string{"TEST_ENV": "1"},
 				},
 				{
-					NodeType:           "reth",
+					NodeType:           clients.Reth,
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					BlockTime:          time.Second,

--- a/runner/benchmark/matrix_test.go
+++ b/runner/benchmark/matrix_test.go
@@ -45,7 +45,7 @@ func TestNewMatrixFromConfig(t *testing.T) {
 					},
 					{
 						ParamType: benchmark.ParamTypeNode,
-						Values:    &[]string{"geth", "erigon"},
+						Values:    &[]string{"geth", "reth"},
 					},
 				},
 			},
@@ -57,7 +57,7 @@ func TestNewMatrixFromConfig(t *testing.T) {
 					BlockTime:          time.Second,
 				},
 				{
-					NodeType:           "erigon",
+					NodeType:           "reth",
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					BlockTime:          time.Second,
@@ -75,7 +75,7 @@ func TestNewMatrixFromConfig(t *testing.T) {
 					},
 					{
 						ParamType: benchmark.ParamTypeNode,
-						Values:    &[]string{"geth", "erigon"},
+						Values:    &[]string{"geth", "reth"},
 					},
 					{
 						ParamType: benchmark.ParamTypeEnv,
@@ -92,7 +92,7 @@ func TestNewMatrixFromConfig(t *testing.T) {
 					Env:                map[string]string{"TEST_ENV": "0"},
 				},
 				{
-					NodeType:           "erigon",
+					NodeType:           "reth",
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					BlockTime:          time.Second,
@@ -106,7 +106,7 @@ func TestNewMatrixFromConfig(t *testing.T) {
 					Env:                map[string]string{"TEST_ENV": "1"},
 				},
 				{
-					NodeType:           "erigon",
+					NodeType:           "reth",
 					TransactionPayload: []benchmark.TransactionPayload{{Type: "simple"}, {Type: "complex"}},
 					GasLimit:           benchmark.DefaultParams.GasLimit,
 					BlockTime:          time.Second,

--- a/runner/clients/interface.go
+++ b/runner/clients/interface.go
@@ -1,6 +1,8 @@
 package clients
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/base/base-bench/runner/clients/geth"
@@ -22,9 +24,24 @@ func NewClient(client Client, logger log.Logger, options *config.ClientOptions) 
 }
 
 // Client is an enum for the different clients that can be used to run the chain.
-type Client uint
+type Client string
 
 const (
-	Reth Client = iota
-	Geth
+	Reth Client = "reth"
+	Geth Client = "geth"
 )
+
+var (
+	ErrInvalidClient = fmt.Errorf("invalid client type")
+)
+
+func ParseClient(client string) (Client, error) {
+	switch client {
+	case "reth":
+		return Reth, nil
+	case "geth":
+		return Geth, nil
+	default:
+		return "", ErrInvalidClient
+	}
+}

--- a/runner/metrics/metrics_interface.go
+++ b/runner/metrics/metrics_interface.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/base/base-bench/runner/clients"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -43,7 +44,7 @@ func (m *Metrics) GetMetricTypes() map[string]bool {
 func NewMetricsCollector(
 	log log.Logger,
 	client *ethclient.Client,
-	clientName string) MetricsCollector {
+	clientName clients.Client) MetricsCollector {
 	switch clientName {
 	case "geth":
 		return NewGethMetricsCollector(log, client)

--- a/runner/service.go
+++ b/runner/service.go
@@ -121,13 +121,6 @@ func (s *service) runTest(ctx context.Context, params benchmark.Params, rootDir 
 	}()
 
 	// TODO: serialize these nicer so we can pass them directly
-	nodeType := clients.Geth
-	switch params.NodeType {
-	case "geth":
-		nodeType = clients.Geth
-	case "reth":
-		nodeType = clients.Reth
-	}
 	logger := s.log.With("nodeType", params.NodeType)
 
 	options := s.config.ClientOptions()
@@ -136,7 +129,7 @@ func (s *service) runTest(ctx context.Context, params benchmark.Params, rootDir 
 	clientCtx, cancelClient := context.WithCancel(ctx)
 	defer cancelClient()
 
-	client := clients.NewClient(nodeType, logger, &options)
+	client := clients.NewClient(params.NodeType, logger, &options)
 	defer client.Stop()
 
 	err = client.Run(clientCtx, chainCfgPath, jwtSecretPath, dataDirPath)


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

Use a type instead of a string for node type to improve safety of config and reduce parsing logic in other parts of the code.
