### PR TITLE
feat: add configurable ports for geth and reth clients

### DIFF
--- a/runner/clients/geth/client.go
+++ b/runner/clients/geth/client.go
@@ -3,9 +3,11 @@ package geth
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -79,11 +81,11 @@ func (g *GethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 	args = append(args, "--http")
 
 	// TODO: allocate these dynamically eventually
-	args = append(args, "--http.port", "8545")
-	args = append(args, "--authrpc.port", "8551")
+	args = append(args, "--http.port", strconv.Itoa(g.options.GethHttpPort))
+	args = append(args, "--authrpc.port", strconv.Itoa(g.options.GethAuthRpcPort))
 	args = append(args, "--metrics")
 	args = append(args, "--metrics.addr", "localhost")
-	args = append(args, "--metrics.port", "8080")
+	args = append(args, "--metrics.port", strconv.Itoa(g.options.GethMetricsPort))
 
 	args = append(args, "--http.api", "eth,net,web3,miner")
 	args = append(args, "--authrpc.jwtsecret", jwtSecretPath)
@@ -118,7 +120,7 @@ func (g *GethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 		return err
 	}
 
-	g.clientURL = "http://127.0.0.1:8545"
+	g.clientURL = fmt.Sprintf("http://127.0.0.1:%d", g.options.GethHttpPort)
 	rpcClient, err := rpc.Dial(g.clientURL)
 	if err != nil {
 		return errors.Wrap(err, "failed to dial rpc")
@@ -131,7 +133,7 @@ func (g *GethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 		return errors.Wrap(err, "geth rpc failed to start")
 	}
 
-	l2Node, err := client.NewRPC(ctx, g.logger, "http://127.0.0.1:8551", client.WithGethRPCOptions(rpc.WithHTTPAuth(node.NewJWTAuth(jwtSecret))))
+	l2Node, err := client.NewRPC(ctx, g.logger, fmt.Sprintf("http://127.0.0.1:%d", g.options.GethAuthRpcPort), client.WithGethRPCOptions(rpc.WithHTTPAuth(node.NewJWTAuth(jwtSecret))))
 	if err != nil {
 		return err
 	}

--- a/runner/clients/geth/options/options.go
+++ b/runner/clients/geth/options/options.go
@@ -3,5 +3,8 @@ package options
 // GethOptions are options that are specified at runtime for the geth client.
 type GethOptions struct {
 	// GethBin is the path to the geth binary to use in tests.
-	GethBin string
+	GethBin         string
+	GethHttpPort    int
+	GethAuthRpcPort int
+	GethMetricsPort int
 }

--- a/runner/clients/reth/client.go
+++ b/runner/clients/reth/client.go
@@ -3,9 +3,11 @@ package reth
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -57,11 +59,11 @@ func (r *RethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 
 	// todo: make this dynamic eventually
 	args = append(args, "--http")
-	args = append(args, "--http.port", "8545")
+	args = append(args, "--http.port", strconv.Itoa(r.options.RethHttpPort))
 	args = append(args, "--http.api", "eth,net,web3,miner")
-	args = append(args, "--authrpc.port", "8551")
+	args = append(args, "--authrpc.port", strconv.Itoa(r.options.RethAuthRpcPort))
 	args = append(args, "--authrpc.jwtsecret", jwtSecretPath)
-	args = append(args, "--metrics", "8080")
+	args = append(args, "--metrics", strconv.Itoa(r.options.RethMetricsPort))
 	args = append(args, "-vvv")
 
 	// read jwt secret
@@ -105,7 +107,7 @@ func (r *RethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 		return err
 	}
 
-	r.clientURL = "http://127.0.0.1:8545"
+	r.clientURL = fmt.Sprintf("http://127.0.0.1:%d", r.options.RethHttpPort)
 	rpcClient, err := rpc.Dial(r.clientURL)
 	if err != nil {
 		return errors.Wrap(err, "failed to dial rpc")
@@ -118,7 +120,7 @@ func (r *RethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 		return errors.Wrap(err, "geth rpc failed to start")
 	}
 
-	l2Node, err := client.NewRPC(ctx, r.logger, "http://127.0.0.1:8551", client.WithGethRPCOptions(rpc.WithHTTPAuth(node.NewJWTAuth(jwtSecret))))
+	l2Node, err := client.NewRPC(ctx, r.logger, fmt.Sprintf("http://127.0.0.1:%d", r.options.RethAuthRpcPort), client.WithGethRPCOptions(rpc.WithHTTPAuth(node.NewJWTAuth(jwtSecret))))
 	if err != nil {
 		return err
 	}

--- a/runner/clients/reth/options/options.go
+++ b/runner/clients/reth/options/options.go
@@ -3,5 +3,8 @@ package options
 // RethOptions contains the options for the reth client determined by the test.
 type RethOptions struct {
 	// RethBin is the path to the reth binary.
-	RethBin string
+	RethBin         string
+	RethHttpPort    int
+	RethAuthRpcPort int
+	RethMetricsPort int
 }

--- a/runner/config/client.go
+++ b/runner/config/client.go
@@ -20,10 +20,16 @@ type ClientOptions struct {
 func ReadClientOptions(ctx *cli.Context) ClientOptions {
 	options := ClientOptions{
 		RethOptions: rethoptions.RethOptions{
-			RethBin: ctx.String(flags.RethBinFlagName),
+			RethBin:         ctx.String(flags.RethBin),
+			RethHttpPort:    ctx.Int(flags.RethHttpPort),
+			RethAuthRpcPort: ctx.Int(flags.RethAuthRpcPort),
+			RethMetricsPort: ctx.Int(flags.RethMetricsPort),
 		},
 		GethOptions: gethoptions.GethOptions{
-			GethBin: ctx.String(flags.GethBinFlagName),
+			GethBin:         ctx.String(flags.GethBin),
+			GethHttpPort:    ctx.Int(flags.GethHttpPort),
+			GethAuthRpcPort: ctx.Int(flags.GethAuthRpcPort),
+			GethMetricsPort: ctx.Int(flags.GethMetricsPort),
 		},
 	}
 

--- a/runner/flags/flags.go
+++ b/runner/flags/flags.go
@@ -7,23 +7,78 @@ import (
 )
 
 const (
-	RethBinFlagName = "reth-bin"
-	GethBinFlagName = "geth-bin"
+	RethBin         = "reth-bin"
+	RethHttpPort    = "reth-http-port"
+	RethAuthRpcPort = "reth-auth-rpc-port"
+	RethMetricsPort = "reth-metrics-port"
+	GethBin         = "geth-bin"
+	GethHttpPort    = "geth-http-port"
+	GethAuthRpcPort = "geth-auth-rpc-port"
+	GethMetricsPort = "geth-metrics-port"
+)
+
+const (
+	// Geth defaults
+	DefaultGethHTTPPort    = 8545
+	DefaultGethAuthRPCPort = 8551
+	DefaultGethMetricsPort = 8080
+
+	// Reth defaults
+	DefaultRethHTTPPort    = 9545
+	DefaultRethAuthRPCPort = 9551
+	DefaultRethMetricsPort = 9080
 )
 
 func CLIFlags(envPrefix string) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:    RethBinFlagName,
+			Name:    RethBin,
 			Usage:   "Reth binary path",
 			Value:   "reth",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "RETH_BIN"),
 		},
+		&cli.IntFlag{
+			Name:    RethHttpPort,
+			Usage:   "Reth HTTP port",
+			Value:   DefaultRethHTTPPort,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "RETH_HTTP_PORT"),
+		},
+		&cli.IntFlag{
+			Name:    RethAuthRpcPort,
+			Usage:   "Reth Auth RPC port",
+			Value:   DefaultRethAuthRPCPort,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "RETH_AUTHRPC_PORT"),
+		},
+		&cli.IntFlag{
+			Name:    RethMetricsPort,
+			Usage:   "Reth Metrics port",
+			Value:   DefaultRethMetricsPort,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "RETH_METRICS_PORT"),
+		},
+
 		&cli.StringFlag{
-			Name:    GethBinFlagName,
+			Name:    GethBin,
 			Usage:   "Geth binary path",
 			Value:   "geth",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "GETH_BIN"),
+		},
+		&cli.IntFlag{
+			Name:    GethHttpPort,
+			Usage:   "Geth HTTP port",
+			Value:   DefaultGethHTTPPort,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "GETH_HTTP_PORT"),
+		},
+		&cli.IntFlag{
+			Name:    GethAuthRpcPort,
+			Usage:   "Geth Auth RPC port",
+			Value:   DefaultGethAuthRPCPort,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "GETH_AUTHRPC_PORT"),
+		},
+		&cli.IntFlag{
+			Name:    GethMetricsPort,
+			Usage:   "Geth Metrics port",
+			Value:   DefaultGethMetricsPort,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "GETH_METRICS_PORT"),
 		},
 	}
 }

--- a/runner/metrics/geth_metrics.go
+++ b/runner/metrics/geth_metrics.go
@@ -11,16 +11,18 @@ import (
 )
 
 type GethMetricsCollector struct {
-	log     log.Logger
-	client  *ethclient.Client
-	metrics []Metrics
+	log         log.Logger
+	client      *ethclient.Client
+	metrics     []Metrics
+	metricsPort int
 }
 
-func NewGethMetricsCollector(log log.Logger, client *ethclient.Client) *GethMetricsCollector {
+func NewGethMetricsCollector(log log.Logger, client *ethclient.Client, metricsPort int) *GethMetricsCollector {
 	return &GethMetricsCollector{
-		log:     log,
-		client:  client,
-		metrics: make([]Metrics, 0),
+		log:         log,
+		client:      client,
+		metricsPort: metricsPort,
+		metrics:     make([]Metrics, 0),
 	}
 }
 
@@ -35,7 +37,7 @@ func (g *GethMetricsCollector) GetMetricTypes() map[string]bool {
 }
 
 func (g *GethMetricsCollector) GetMetricsEndpoint() string {
-	return "http://127.0.0.1:8080/debug/metrics"
+	return fmt.Sprintf("http://127.0.0.1:%d/debug/metrics", g.metricsPort)
 }
 
 func (g *GethMetricsCollector) GetMetrics() []Metrics {

--- a/runner/metrics/metrics_interface.go
+++ b/runner/metrics/metrics_interface.go
@@ -44,12 +44,13 @@ func (m *Metrics) GetMetricTypes() map[string]bool {
 func NewMetricsCollector(
 	log log.Logger,
 	client *ethclient.Client,
-	clientName string) MetricsCollector {
+	clientName string,
+	metricsPort int) MetricsCollector {
 	switch clientName {
 	case "geth":
-		return NewGethMetricsCollector(log, client)
+		return NewGethMetricsCollector(log, client, metricsPort)
 	case "reth":
-		return NewRethMetricsCollector(log, client)
+		return NewRethMetricsCollector(log, client, metricsPort)
 	}
 	panic(fmt.Sprintf("unknown client: %s", clientName))
 }

--- a/runner/metrics/reth_metrics.go
+++ b/runner/metrics/reth_metrics.go
@@ -13,21 +13,23 @@ import (
 )
 
 type RethMetricsCollector struct {
-	log     log.Logger
-	client  *ethclient.Client
-	metrics []Metrics
+	log         log.Logger
+	client      *ethclient.Client
+	metrics     []Metrics
+	metricsPort int
 }
 
-func NewRethMetricsCollector(log log.Logger, client *ethclient.Client) *RethMetricsCollector {
+func NewRethMetricsCollector(log log.Logger, client *ethclient.Client, metricsPort int) *RethMetricsCollector {
 	return &RethMetricsCollector{
-		log:     log,
-		client:  client,
-		metrics: make([]Metrics, 0),
+		log:         log,
+		client:      client,
+		metricsPort: metricsPort,
+		metrics:     make([]Metrics, 0),
 	}
 }
 
 func (r *RethMetricsCollector) GetMetricsEndpoint() string {
-	return "http://localhost:8080/metrics"
+	return fmt.Sprintf("http://localhost:%d/metrics", r.metricsPort)
 }
 
 func (r *RethMetricsCollector) GetMetrics() []Metrics {

--- a/runner/service.go
+++ b/runner/service.go
@@ -268,11 +268,15 @@ func (s *service) runTest(ctx context.Context, testName string, params benchmark
 
 	// TODO: serialize these nicer so we can pass them directly
 	nodeType := clients.Geth
+	metricsPort := 0
+
 	switch params.NodeType {
 	case "geth":
 		nodeType = clients.Geth
+		metricsPort = s.config.ClientOptions().GethMetricsPort
 	case "reth":
 		nodeType = clients.Reth
+		metricsPort = s.config.ClientOptions().RethMetricsPort
 	}
 
 	client := clients.NewClient(nodeType, log, &options)
@@ -302,7 +306,7 @@ func (s *service) runTest(ctx context.Context, testName string, params benchmark
 	time.Sleep(2 * time.Second)
 
 	// Create metrics collector and writer
-	metricsCollector := metrics.NewMetricsCollector(log, client.Client(), params.NodeType)
+	metricsCollector := metrics.NewMetricsCollector(log, client.Client(), params.NodeType, metricsPort)
 	metricsWriter := metrics.NewFileMetricsWriter(testDirs.metricsPath)
 
 	// Wait for RPC to become available


### PR DESCRIPTION
# Description

1. Add CLI flags for HTTP, AuthRPC, and Metrics ports
2. Update client options to support port configuration
3. Modify clients to use configured ports

Next up: add a manger to allocate port to nodes if ports are used. 

# Testing

<!-- How was the code in this PR tested? -->
