### PR TITLE
feat: move metrics and improve tx injection

### DIFF
--- a/runner/metrics/metrics_interface.go
+++ b/runner/metrics/metrics_interface.go
@@ -13,29 +13,29 @@ import (
 )
 
 type MetricsCollector interface {
-	Collect(ctx context.Context, blockNumber uint64) error
-	GetMetricsEndpoint() string
-	GetMetrics() []Metrics
+	Collect(ctx context.Context, metrics *BlockMetrics) error
+	GetMetrics() []BlockMetrics
 }
 
-type Metrics struct {
+type BlockMetrics struct {
 	BlockNumber      uint64
 	Timestamp        time.Time
 	ExecutionMetrics map[string]interface{}
 }
 
-func NewMetrics() *Metrics {
-	return &Metrics{
+func NewBlockMetrics(blockNumber uint64) *BlockMetrics {
+	return &BlockMetrics{
+		BlockNumber:      blockNumber,
 		ExecutionMetrics: make(map[string]interface{}),
 		Timestamp:        time.Now(),
 	}
 }
 
-func (m *Metrics) AddExecutionMetric(name string, value interface{}) {
+func (m *BlockMetrics) AddExecutionMetric(name string, value interface{}) {
 	m.ExecutionMetrics[name] = value
 }
 
-func (m *Metrics) GetMetricTypes() map[string]bool {
+func (m *BlockMetrics) GetMetricTypes() map[string]bool {
 	return map[string]bool{
 		"execution": true,
 	}
@@ -56,7 +56,7 @@ func NewMetricsCollector(
 }
 
 type MetricsWriter interface {
-	Write(metrics []Metrics) error
+	Write(metrics []BlockMetrics) error
 }
 
 type FileMetricsWriter struct {
@@ -71,7 +71,7 @@ func NewFileMetricsWriter(baseDir string) *FileMetricsWriter {
 
 const MetricsFileName = "metrics.json"
 
-func (w *FileMetricsWriter) Write(metrics []Metrics) error {
+func (w *FileMetricsWriter) Write(metrics []BlockMetrics) error {
 	filename := path.Join(w.BaseDir, MetricsFileName)
 
 	data, err := json.MarshalIndent(metrics, "", "  ")

--- a/runner/metrics/reth_metrics.go
+++ b/runner/metrics/reth_metrics.go
@@ -15,7 +15,7 @@ import (
 type RethMetricsCollector struct {
 	log         log.Logger
 	client      *ethclient.Client
-	metrics     []Metrics
+	metrics     []BlockMetrics
 	metricsPort int
 }
 
@@ -24,7 +24,7 @@ func NewRethMetricsCollector(log log.Logger, client *ethclient.Client, metricsPo
 		log:         log,
 		client:      client,
 		metricsPort: metricsPort,
-		metrics:     make([]Metrics, 0),
+		metrics:     make([]BlockMetrics, 0),
 	}
 }
 
@@ -32,7 +32,7 @@ func (r *RethMetricsCollector) GetMetricsEndpoint() string {
 	return fmt.Sprintf("http://localhost:%d/metrics", r.metricsPort)
 }
 
-func (r *RethMetricsCollector) GetMetrics() []Metrics {
+func (r *RethMetricsCollector) GetMetrics() []BlockMetrics {
 	return r.metrics
 }
 
@@ -43,7 +43,7 @@ func (r *RethMetricsCollector) GetMetricTypes() map[string]bool {
 	}
 }
 
-func (r *RethMetricsCollector) Collect(ctx context.Context, blockNumber uint64) error {
+func (r *RethMetricsCollector) Collect(ctx context.Context, m *BlockMetrics) error {
 	resp, err := http.Get(r.GetMetricsEndpoint())
 	if err != nil {
 		return fmt.Errorf("failed to get metrics: %w", err)
@@ -62,9 +62,6 @@ func (r *RethMetricsCollector) Collect(ctx context.Context, blockNumber uint64) 
 	if err != nil {
 		return fmt.Errorf("failed to parse metrics: %w", err)
 	}
-
-	m := NewMetrics()
-	m.BlockNumber = blockNumber
 
 	metricTypes := r.GetMetricTypes()
 

--- a/runner/network/consensus/client.go
+++ b/runner/network/consensus/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/base/base-bench/runner/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -29,15 +28,15 @@ type BaseConsensusClient struct {
 	authClient client.RPC
 	options    ConsensusClientOptions
 
-	headBlockHash common.Hash
-	lastTimestamp uint64
+	headBlockHash   common.Hash
+	headBlockNumber uint64
+	lastTimestamp   uint64
 
 	currentPayloadID *engine.PayloadID
-	metricsCollector metrics.MetricsCollector
 }
 
 // NewBaseConsensusClient creates a new base consensus client.
-func NewBaseConsensusClient(log log.Logger, client *ethclient.Client, authClient client.RPC, genesis *core.Genesis, metricsCollector metrics.MetricsCollector, options ConsensusClientOptions) *BaseConsensusClient {
+func NewBaseConsensusClient(log log.Logger, client *ethclient.Client, authClient client.RPC, genesis *core.Genesis, options ConsensusClientOptions) *BaseConsensusClient {
 	genesisHash := genesis.ToBlock().Hash()
 	genesisTimestamp := genesis.Timestamp
 
@@ -46,10 +45,10 @@ func NewBaseConsensusClient(log log.Logger, client *ethclient.Client, authClient
 		client:           client,
 		authClient:       authClient,
 		headBlockHash:    genesisHash,
+		headBlockNumber:  genesis.Number,
 		lastTimestamp:    genesisTimestamp,
 		options:          options,
 		currentPayloadID: nil,
-		metricsCollector: metricsCollector,
 	}
 }
 
@@ -121,11 +120,4 @@ func (b *BaseConsensusClient) newPayload(ctx context.Context, params *engine.Exe
 	}
 
 	return nil
-}
-
-// collectMetrics collects metrics after block processing.
-func (b *BaseConsensusClient) collectMetrics(ctx context.Context, blockNumber uint64) {
-	if err := b.metricsCollector.Collect(ctx, blockNumber); err != nil {
-		b.log.Error("Failed to collect metrics", "error", err)
-	}
 }

--- a/runner/payload/tx_fuzz.go
+++ b/runner/payload/tx_fuzz.go
@@ -50,6 +50,11 @@ func (t *TxFuzzPayloadWorker) Setup(ctx context.Context) error {
 	return nil
 }
 
+func (t *TxFuzzPayloadWorker) SendTxs(ctx context.Context) error {
+	// TODO: Implement SendTxs for the tx fuzzer
+	return nil
+}
+
 // Run executes the transaction fuzzer
 func (t *TxFuzzPayloadWorker) Run(ctx context.Context) error {
 	t.log.Info("Starting tx fuzzer", "binary", t.txFuzzBin)


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

Move metrics out of the client and into the benchmark to pass down to the client.

This allows us to capture latency metrics for RPC methods.

Instead of the transaction payload generator running every second, inject payloads synchronously so we can measure the time it takes to send and wait if block generation takes too long.

# Testing

<!-- How was the code in this PR tested? -->

Tested end to end with report generator.
