### PR TITLE
feat: add metrics summary to result metadata

### DIFF
--- a/runner/benchmark/matrix.go
+++ b/runner/benchmark/matrix.go
@@ -119,20 +119,6 @@ func (bc *TestDefinition) Check() error {
 	return nil
 }
 
-// BenchmarkRun is the output JSON metadata for a benchmark run.
-type BenchmarkRun struct {
-	SourceFile      string                 `json:"sourceFile"`
-	OutputDir       string                 `json:"outputDir"`
-	TestName        string                 `json:"testName"`
-	TestDescription string                 `json:"testDescription"`
-	TestConfig      map[string]interface{} `json:"testConfig"`
-}
-
-// BenchmarkRuns is the output JSON metadata file schema.
-type BenchmarkRuns struct {
-	Runs []BenchmarkRun `json:"runs"`
-}
-
 // TestPlan represents a list of test runs to be executed.
 type TestPlan []TestRun
 
@@ -148,24 +134,6 @@ func NewTestPlanFromConfig(c []TestDefinition, testFileName string) (TestPlan, e
 	}
 
 	return testPlan, nil
-}
-
-func (tp TestPlan) ToMetadata() BenchmarkRuns {
-	metadata := BenchmarkRuns{
-		Runs: make([]BenchmarkRun, 0, len(tp)),
-	}
-
-	for _, params := range tp {
-		metadata.Runs = append(metadata.Runs, BenchmarkRun{
-			SourceFile:      params.TestFile,
-			TestName:        params.Name,
-			TestDescription: params.Description,
-			TestConfig:      params.Params.ToConfig(),
-			OutputDir:       params.OutputDir,
-		})
-	}
-
-	return metadata
 }
 
 var alphaNumericRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)

--- a/runner/benchmark/result_metadata.go
+++ b/runner/benchmark/result_metadata.go
@@ -1,0 +1,68 @@
+package benchmark
+
+import "time"
+
+type SequencerKeyMetrics struct {
+	CommonKeyMetrics
+	AverageFCULatency        float64 `json:"forkChoiceUpdated"`
+	AverageGetPayloadLatency float64 `json:"getPayload"`
+	AverageSendTxsLatency    float64 `json:"sendTxs"`
+}
+
+type ValidatorKeyMetrics struct {
+	CommonKeyMetrics
+	AverageNewPayloadLatency float64 `json:"newPayload"`
+}
+
+type CommonKeyMetrics struct {
+	AverageGasPerSecond float64 `json:"gasPerSecond"`
+}
+
+type BenchmarkRunResult struct {
+	Success          bool                `json:"success"`
+	SequencerMetrics SequencerKeyMetrics `json:"sequencerMetrics"`
+	ValidatorMetrics ValidatorKeyMetrics `json:"validatorMetrics"`
+}
+
+// BenchmarkRun is the output JSON metadata for a benchmark run.
+type BenchmarkRun struct {
+	SourceFile      string                 `json:"sourceFile"`
+	OutputDir       string                 `json:"outputDir"`
+	TestName        string                 `json:"testName"`
+	TestDescription string                 `json:"testDescription"`
+	TestConfig      map[string]interface{} `json:"testConfig"`
+	Result          *BenchmarkRunResult    `json:"result"`
+}
+
+// BenchmarkRuns is the output JSON metadata file schema.
+type BenchmarkRuns struct {
+	Runs      []BenchmarkRun `json:"runs"`
+	CreatedAt time.Time      `json:"createdAt"`
+}
+
+func (runs *BenchmarkRuns) AddResult(testIdx int, runResult BenchmarkRunResult) {
+	if testIdx < 0 || testIdx >= len(runs.Runs) {
+		return
+	}
+
+	runs.Runs[testIdx].Result = &runResult
+}
+
+func BenchmarkMetadataFromTestPlan(testPlan TestPlan) BenchmarkRuns {
+	metadata := BenchmarkRuns{
+		Runs:      make([]BenchmarkRun, 0, len(testPlan)),
+		CreatedAt: time.Now(),
+	}
+
+	for _, params := range testPlan {
+		metadata.Runs = append(metadata.Runs, BenchmarkRun{
+			SourceFile:      params.TestFile,
+			TestName:        params.Name,
+			TestDescription: params.Description,
+			TestConfig:      params.Params.ToConfig(),
+			OutputDir:       params.OutputDir,
+		})
+	}
+
+	return metadata
+}

--- a/runner/network/network_benchmark.go
+++ b/runner/network/network_benchmark.go
@@ -36,6 +36,9 @@ type NetworkBenchmark struct {
 	sequencerOptions *config.InternalClientOptions
 	validatorOptions *config.InternalClientOptions
 
+	collectedSequencerMetrics *benchmark.SequencerKeyMetrics
+	collectedValidatorMetrics *benchmark.ValidatorKeyMetrics
+
 	genesis *core.Genesis
 	config  config.Config
 }
@@ -108,7 +111,11 @@ func (nb *NetworkBenchmark) benchmarkSequencer(ctx context.Context) ([]engine.Ex
 	metricsWriter := metrics.NewFileMetricsWriter(nb.sequencerOptions.MetricsPath)
 
 	defer func() {
-		if err := metricsWriter.Write(metricsCollector.GetMetrics()); err != nil {
+		sequencerMetrics := metricsCollector.GetMetrics()
+
+		nb.collectedSequencerMetrics = metrics.BlockMetricsToSequencerSummary(sequencerMetrics)
+
+		if err := metricsWriter.Write(sequencerMetrics); err != nil {
 			nb.log.Error("Failed to write metrics", "error", err)
 		}
 	}()
@@ -245,7 +252,11 @@ func (nb *NetworkBenchmark) benchmarkValidator(ctx context.Context, payloads []e
 	metricsWriter := metrics.NewFileMetricsWriter(nb.validatorOptions.MetricsPath)
 
 	defer func() {
-		if err := metricsWriter.Write(metricsCollector.GetMetrics()); err != nil {
+		validatorMetrics := metricsCollector.GetMetrics()
+
+		nb.collectedValidatorMetrics = metrics.BlockMetricsToValidatorSummary(validatorMetrics)
+
+		if err := metricsWriter.Write(validatorMetrics); err != nil {
 			nb.log.Error("Failed to write metrics", "error", err)
 		}
 	}()
@@ -260,4 +271,16 @@ func (nb *NetworkBenchmark) benchmarkValidator(ctx context.Context, payloads []e
 		return err
 	}
 	return nil
+}
+
+func (nb *NetworkBenchmark) GetResult() (*benchmark.BenchmarkRunResult, error) {
+	if nb.collectedSequencerMetrics == nil || nb.collectedValidatorMetrics == nil {
+		return nil, errors.New("metrics not collected")
+	}
+
+	return &benchmark.BenchmarkRunResult{
+		SequencerMetrics: *nb.collectedSequencerMetrics,
+		ValidatorMetrics: *nb.collectedValidatorMetrics,
+		Success:          true,
+	}, nil
 }


### PR DESCRIPTION
# Description

Adds optional result metric summary to metadata file. This will allow easy bulk listing of test results without having to read every single test metrics file.

Test metadata is now written at the end of each test as well as before tests begin.

# Testing

Added this to the frontend in another PR.