### PR TITLE
fix: remove hardcoded gas limit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
         mkdir ${{ runner.temp }}/data-dir
         mkdir ${{ runner.temp }}/output
         go run benchmark/cmd/main.go \
-          --log.level debug \
+          --log.level info \
           run \
           --config ./configs/basic.yml \
           --root-dir ${{ runner.temp }}/data-dir \

--- a/configs/basic.yml
+++ b/configs/basic.yml
@@ -9,6 +9,7 @@
         - reth
         - geth
     - type: num_blocks
-      value: 20
+      value: 10
     - type: gas_limit
-      value: 10000000000
+      value: 1000000000
+             

--- a/runner/network/network_benchmark.go
+++ b/runner/network/network_benchmark.go
@@ -210,6 +210,15 @@ func (nb *NetworkBenchmark) benchmarkSequencer(ctx context.Context) ([]engine.Ex
 				return
 			}
 
+			if payload == nil {
+				errChan <- errors.New("received nil payload from consensus client")
+				return
+			}
+
+			// Now safe to access payload fields
+			nb.log.Info("Gas limit", "gasLimit", payload.GasLimit)
+			nb.log.Info("Gas used", "gasUsed", payload.GasUsed)
+
 			time.Sleep(500 * time.Millisecond)
 
 			err = metricsCollector.Collect(benchmarkCtx, blockMetrics)


### PR DESCRIPTION
# Description

can use the gaslimit param now
also lowers the github action limit for numblocks and gaslimit 

# Testing

<!-- How was the code in this PR tested? -->
