### PR TITLE
ci: bump actions/cache to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
         go mod download
 
     - name: Cache binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-bin
       with:
         path: ${{ runner.temp }}/bin

--- a/.github/workflows/public-benchmarks.yaml
+++ b/.github/workflows/public-benchmarks.yaml
@@ -24,7 +24,7 @@ jobs:
           go mod download
 
       - name: Cache binaries
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-bin
         with:
           path: ${{ runner.temp }}/bin


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/cache@v4. Pure maintenance update, behaviour unchanged.