### PR TITLE
chore: allow log level to be specified for external commands

### DIFF
--- a/runner/logger/logger.go
+++ b/runner/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"io"
+	"log/slog"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -15,6 +16,8 @@ type LogWriter struct {
 	logger log.Logger
 	// should never contain new lines
 	buffer []byte
+
+	level slog.Level
 }
 
 // escapeMessage checks if the provided string needs escaping/quoting, similarly
@@ -45,6 +48,15 @@ func NewLogWriter(logger log.Logger) *LogWriter {
 	return &LogWriter{
 		logger: logger,
 		buffer: make([]byte, 0, maxBufferedLogLineSize),
+		level:  slog.LevelDebug,
+	}
+}
+
+func NewLogWriterWithLevel(logger log.Logger, level slog.Level) *LogWriter {
+	return &LogWriter{
+		logger: logger,
+		buffer: make([]byte, 0, maxBufferedLogLineSize),
+		level:  level,
 	}
 }
 
@@ -54,7 +66,7 @@ func (lw *LogWriter) flushBuffer() {
 		return
 	}
 
-	lw.logger.Debug(escapeMessage("+ " + string(lw.buffer)))
+	lw.logger.Write(lw.level, escapeMessage("+ "+string(lw.buffer)))
 	lw.buffer = lw.buffer[:0]
 }
 


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

Allows log level of the log writer to be adjusted so we can specify some clients to be debug and some to be info logs.

# Testing

<!-- How was the code in this PR tested? -->

Tested end to end with other features in this stack.