### PR TITLE
feat: add proof benchmark and split up benchmark phases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,119 +3,132 @@ name: test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
 
 jobs:
   go-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.24
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.24
 
-    - name: Install project dependencies
-      run: | 
-        go mod download
+      - name: Install project dependencies
+        run: |
+          go mod download
 
-    - name: Lint Go
-      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
-      with:
-        version: v2.0
+      - name: Lint Go
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        with:
+          version: v2.0
 
   go-test:
     outputs:
       COVERAGE: ${{ steps.unit.outputs.coverage }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.24
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.24
 
-    - name: Install project dependencies
-      run: | 
-        go mod download
-    - name: Run Unit Tests
-      id: unit
-      run: | 
-        go test -v -coverprofile=coverage.out ./... 
-    
+      - name: Install project dependencies
+        run: |
+          go mod download
+      - name: Run Unit Tests
+        id: unit
+        run: |
+          go test -v -coverprofile=coverage.out ./...
+
   basic-benchmarks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.24
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.24
 
-    - name: Set up Rust
-      uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
 
-    - name: Install project dependencies
-      run: | 
-        go mod download
+      - name: Install project dependencies
+        run: |
+          go mod download
 
-    - name: Cache binaries
-      uses: actions/cache@v3
-      id: cache-bin
-      with:
-        path: ${{ runner.temp }}/bin
-        key: ${{ runner.os }}-binaries
+      - name: Cache binaries
+        uses: actions/cache@v3
+        id: cache-bin
+        with:
+          path: ${{ runner.temp }}/bin
+          key: ${{ runner.os }}-binaries
 
-    - name: Download geth and reth
-      if: steps.cache-bin.outputs.cache-hit != 'true'
-      run: | 
-        mkdir -p ${{ runner.temp }}/bin
+      - name: Download geth and reth
+        if: steps.cache-bin.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ${{ runner.temp }}/bin
 
-        git clone https://github.com/paradigmxyz/reth
-        git -C reth checkout --force fad870e3508adcc150faa4554111368e0e16f43b
-        
-        pushd reth
-        cargo build --features asm-keccak --profile release --bin op-reth --manifest-path crates/optimism/bin/Cargo.toml
-        cp ./target/release/op-reth ${{ runner.temp }}/bin/reth
-        popd
-        chmod +x ${{ runner.temp }}/bin/reth
+          git clone https://github.com/paradigmxyz/reth
+          git -C reth checkout --force fad870e3508adcc150faa4554111368e0e16f43b
 
-        git clone https://github.com/ethereum-optimism/op-geth
-        git -C op-geth checkout --force 4bc345b22fbee14d3162becd197373a9565b7c6d
+          pushd reth
+          cargo build --features asm-keccak --profile release --bin op-reth --manifest-path crates/optimism/bin/Cargo.toml
+          cp ./target/release/op-reth ${{ runner.temp }}/bin/reth
+          popd
+          chmod +x ${{ runner.temp }}/bin/reth
 
-        pushd op-geth
-        make geth
-        cp ./build/bin/geth ${{ runner.temp }}/bin/geth
-        chmod +x ${{ runner.temp }}/bin/geth
-        popd
+          git clone https://github.com/ethereum-optimism/op-geth
+          git -C op-geth checkout --force 4bc345b22fbee14d3162becd197373a9565b7c6d
 
-        echo "binaries compiled:"
-        ls -la ${{ runner.temp }}/bin
+          pushd op-geth
+          make geth
+          cp ./build/bin/geth ${{ runner.temp }}/bin/geth
+          chmod +x ${{ runner.temp }}/bin/geth
+          popd
 
-    - name: Run Basic Benchmarks
-      id: unit
-      run: | 
-        mkdir ${{ runner.temp }}/data-dir
-        mkdir ${{ runner.temp }}/output
-        go run benchmark/cmd/main.go \
-          --log.level info \
-          run \
-          --config ./configs/basic.yml \
-          --root-dir ${{ runner.temp }}/data-dir \
-          --output-dir ${{ runner.temp }}/output \
-          --reth-bin ${{ runner.temp }}/bin/reth \
-          --geth-bin ${{ runner.temp }}/bin/geth
-    - name: Run Contract Benchmark
-      id: contract
-      run: | 
-        go run benchmark/cmd/main.go \
-          --log.level info \
-          run \
-          --config ./configs/contract.yml \
-          --root-dir ${{ runner.temp }}/data-dir \
-          --output-dir ${{ runner.temp }}/output \
-          --geth-bin ${{ runner.temp }}/bin/geth
+          echo "binaries compiled:"
+          ls -la ${{ runner.temp }}/bin
+
+      - name: Run op-program Benchmark
+        id: op-program
+        run: |
+          curl https://mise.run | sh
+          pushd op-program
+          mise x -- ./build.sh
+          popd
+          go run benchmark/cmd/main.go \
+            --log.level info \
+            run \
+            --config ./configs/proof-program.yml \
+            --root-dir ${{ runner.temp }}/data-dir \
+            --output-dir ${{ runner.temp }}/output \
+            --geth-bin ${{ runner.temp }}/bin/geth
+
+      - name: Run Basic Benchmarks
+        id: unit
+        run: |
+          go run benchmark/cmd/main.go \
+            --log.level info \
+            run \
+            --config ./configs/basic.yml \
+            --root-dir ${{ runner.temp }}/data-dir \
+            --output-dir ${{ runner.temp }}/output \
+            --reth-bin ${{ runner.temp }}/bin/reth \
+            --geth-bin ${{ runner.temp }}/bin/geth
+      - name: Run Contract Benchmark
+        id: contract
+        run: |
+          go run benchmark/cmd/main.go \
+            --log.level info \
+            run \
+            --config ./configs/contract.yml \
+            --root-dir ${{ runner.temp }}/data-dir \
+            --output-dir ${{ runner.temp }}/output \
+            --geth-bin ${{ runner.temp }}/bin/geth

--- a/configs/proof-program.yml
+++ b/configs/proof-program.yml
@@ -1,0 +1,22 @@
+- name: Fault proof program execution speed
+  description: Benchmarks the speed that the fault proof program can execute.
+  proof_program:
+    enabled: true
+    type: op-program
+    version: v1.6.1-rc.1
+  variables:
+    - type: transaction_workload
+      values:
+        - transfer-only
+    - type: node_type
+      values:
+        - geth
+        # - reth
+    - type: num_blocks
+      value: 2
+    - type: gas_limit
+      values:
+        - 15000000
+        # - 30000000
+        # - 60000000
+        # - 90000000

--- a/op-program/.gitignore
+++ b/op-program/.gitignore
@@ -1,0 +1,2 @@
+optimism
+versions

--- a/op-program/build.sh
+++ b/op-program/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# In order to benchmark op-program, we need to build op-program with our own chain ID.
+# This script will clone the OP repo, install the necessary configuration files,
+# and build the op-program binary.
+
+CHAIN_ID=13371337
+OP_PROGRAM_VERSION="v1.6.1-rc.1"
+
+# ensure running in op-program directory
+if [ ! -d "../op-program" ]; then
+    echo "Please run this script from the op-program directory."
+    exit 1
+fi
+
+# clone OP repo
+if [ ! -d "op" ]; then
+    git clone https://github.com/ethereum-optimism/optimism.git
+    git -C optimism checkout op-program/$OP_PROGRAM_VERSION
+    echo "Cloned OP repo at version op-program/$OP_PROGRAM_VERSION."
+else
+    echo "OP repo already exists, skipping clone."
+fi
+
+pushd optimism
+
+# install rollup.json and genesis.json
+echo "Installing rollup.json and genesis.json for chain ID $CHAIN_ID..."
+cp ../../rollup.json op-program/chainconfig/configs/13371337-rollup.json
+cp ../../genesis.json op-program/chainconfig/configs/13371337-genesis-l2.json
+
+# update git submodules
+echo "Updating git submodules..."
+git submodule update --init --recursive
+
+# build contracts
+echo "Building contracts..."
+pushd packages/contracts-bedrock
+forge build
+popd
+
+# build op-program
+echo "Building op-program..."
+make op-program
+
+# copy op-program binary to versions directory
+mkdir -p ../versions/$OP_PROGRAM_VERSION
+cp op-program/bin/op-program ../versions/$OP_PROGRAM_VERSION
+popd

--- a/runner/clients/geth/client.go
+++ b/runner/clients/geth/client.go
@@ -63,6 +63,8 @@ func (g *GethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 	// first init geth
 	args := make([]string, 0)
 	args = append(args, "--datadir", g.options.DataDirPath)
+	args = append(args, "--state.scheme", "hash")
+
 	args = append(args, "init", g.options.ChainCfgPath)
 
 	cmd := exec.CommandContext(ctx, g.options.GethBin, args...)
@@ -92,7 +94,9 @@ func (g *GethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 	args = append(args, "--txpool.accountqueue", "1000000")
 	args = append(args, "--maxpeers", "0")
 	args = append(args, "--nodiscover")
-	args = append(args, "--http.api", "eth,net,web3,miner")
+	args = append(args, "--syncmode", "full")
+	args = append(args, "--http.api", "eth,net,web3,miner,debug")
+	args = append(args, "--gcmode", "archive")
 	args = append(args, "--authrpc.jwtsecret", g.options.JWTSecretPath)
 
 	// TODO: make this configurable

--- a/runner/network/consensus/sequencer_consensus.go
+++ b/runner/network/consensus/sequencer_consensus.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/base/base-bench/runner/metrics"
 	"github.com/base/base-bench/runner/network/mempool"
+	"github.com/base/base-bench/runner/network/proofprogram/fakel1"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -19,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -30,21 +32,25 @@ type SequencerConsensusClient struct {
 	*BaseConsensusClient
 	lastTimestamp uint64
 	mempool       mempool.FakeMempool
+	l1Chain       fakel1.L1Chain
+	batcherAddr   common.Address
 }
 
 // NewSequencerConsensusClient creates a new consensus client using the given genesis hash and timestamp.
-func NewSequencerConsensusClient(log log.Logger, client *ethclient.Client, authClient client.RPC, mempool mempool.FakeMempool, options ConsensusClientOptions, headBlockHash common.Hash, headBlockNumber uint64) *SequencerConsensusClient {
+func NewSequencerConsensusClient(log log.Logger, client *ethclient.Client, authClient client.RPC, mempool mempool.FakeMempool, options ConsensusClientOptions, headBlockHash common.Hash, headBlockNumber uint64, l1Chain fakel1.L1Chain, batcherAddr common.Address) *SequencerConsensusClient {
 	base := NewBaseConsensusClient(log, client, authClient, options, headBlockHash, headBlockNumber)
 	return &SequencerConsensusClient{
 		BaseConsensusClient: base,
 		lastTimestamp:       uint64(time.Now().Unix()),
 		mempool:             mempool,
+		l1Chain:             l1Chain,
+		batcherAddr:         batcherAddr,
 	}
 }
 
 // marshalBinaryWithSignature creates the call data for an L1Info transaction.
 func marshalBinaryWithSignature(info *derive.L1BlockInfo, signature []byte) ([]byte, error) {
-	w := bytes.NewBuffer(make([]byte, 0, derive.L1InfoEcotoneLen))
+	w := bytes.NewBuffer(make([]byte, 0, derive.L1InfoIsthmusLen))
 	if err := solabi.WriteSignature(w, signature); err != nil {
 		return nil, err
 	}
@@ -80,34 +86,60 @@ func marshalBinaryWithSignature(info *derive.L1BlockInfo, signature []byte) ([]b
 	if err := solabi.WriteAddress(w, info.BatcherAddr); err != nil {
 		return nil, err
 	}
+	if err := binary.Write(w, binary.BigEndian, info.OperatorFeeScalar); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(w, binary.BigEndian, info.OperatorFeeConstant); err != nil {
+		return nil, err
+	}
 	return w.Bytes(), nil
 }
 
-func (f *SequencerConsensusClient) generatePayloadAttributes(sequencerTxs [][]byte) (*eth.PayloadAttributes, error) {
+func (f *SequencerConsensusClient) generatePayloadAttributes(sequencerTxs [][]byte) (*eth.PayloadAttributes, *common.Hash, error) {
 	gasLimit := eth.Uint64Quantity(f.options.GasLimit)
 
 	var b8 eth.Bytes8
 	copy(b8[:], eip1559.EncodeHolocene1559Params(50, 1))
 
-	timestamp := max(f.lastTimestamp+1, uint64(time.Now().Unix()))
+	timestamp := f.lastTimestamp + 1
+
+	number := uint64(0)
+	time := uint64(0)
+	baseFee := big.NewInt(1)
+	blockHash := common.Hash{}
+	if f.l1Chain != nil {
+		block, err := f.l1Chain.GetBlockByNumber(1)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get block by number: %w", err)
+		}
+		number = block.NumberU64()
+		time = block.Time()
+		baseFee = block.BaseFee()
+		blockHash = block.Hash()
+	}
 
 	l1BlockInfo := &derive.L1BlockInfo{
-		Number:         1,
-		Time:           f.lastTimestamp,
-		BaseFee:        big.NewInt(1),
-		BlockHash:      common.Hash{},
-		SequenceNumber: 0,
-		BatcherAddr:    common.Address{},
+		Number:              number,
+		Time:                time,
+		BaseFee:             baseFee,
+		BlockHash:           blockHash,
+		SequenceNumber:      f.headBlockNumber,
+		BatcherAddr:         f.batcherAddr,
+		BlobBaseFee:         big.NewInt(1),
+		BaseFeeScalar:       1,
+		BlobBaseFeeScalar:   1,
+		OperatorFeeScalar:   0,
+		OperatorFeeConstant: 0,
 	}
 
 	source := derive.L1InfoDepositSource{
-		L1BlockHash: common.Hash{},
-		SeqNumber:   0,
+		L1BlockHash: l1BlockInfo.BlockHash,
+		SeqNumber:   l1BlockInfo.SequenceNumber,
 	}
 
-	data, err := marshalBinaryWithSignature(l1BlockInfo, derive.L1InfoFuncEcotoneBytes4)
+	data, err := marshalBinaryWithSignature(l1BlockInfo, derive.L1InfoFuncIsthmusBytes4)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Set a very large gas limit with `IsSystemTransaction` to ensure
@@ -118,14 +150,14 @@ func (f *SequencerConsensusClient) generatePayloadAttributes(sequencerTxs [][]by
 		To:                  &derive.L1BlockAddress,
 		Mint:                nil,
 		Value:               big.NewInt(0),
-		Gas:                 100_000,
+		Gas:                 1_000_000,
 		IsSystemTransaction: false,
 		Data:                data,
 	}
 	l1Tx := types.NewTx(out)
 	opaqueL1Tx, err := l1Tx.MarshalBinary()
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode L1 info tx: %w", err)
+		return nil, nil, fmt.Errorf("failed to encode L1 info tx: %w", err)
 	}
 
 	sequencerTxsHexBytes := make([]hexutil.Bytes, len(sequencerTxs)+1)
@@ -134,19 +166,21 @@ func (f *SequencerConsensusClient) generatePayloadAttributes(sequencerTxs [][]by
 		sequencerTxsHexBytes[i+1] = hexutil.Bytes(tx)
 	}
 
+	root := crypto.Keccak256Hash([]byte("fake-beacon-block-root"), big.NewInt(int64(number)).Bytes())
+
 	payloadAttrs := &eth.PayloadAttributes{
 		Timestamp:             eth.Uint64Quantity(timestamp),
 		PrevRandao:            eth.Bytes32{},
-		SuggestedFeeRecipient: common.Address{'C'},
+		SuggestedFeeRecipient: common.HexToAddress("0x4200000000000000000000000000000000000011"),
 		Withdrawals:           &types.Withdrawals{},
 		Transactions:          sequencerTxsHexBytes,
 		GasLimit:              &gasLimit,
-		ParentBeaconBlockRoot: &common.Hash{},
+		ParentBeaconBlockRoot: &root,
 		NoTxPool:              false,
 		EIP1559Params:         &b8,
 	}
 
-	return payloadAttrs, nil
+	return payloadAttrs, &root, nil
 }
 
 // Propose starts block generation, waits BlockTime, and generates a block.
@@ -204,7 +238,7 @@ func (f *SequencerConsensusClient) Propose(ctx context.Context, blockMetrics *me
 
 	f.log.Info("Starting block building")
 
-	payloadAttrs, err := f.generatePayloadAttributes(sequencerTxs)
+	payloadAttrs, beaconRoot, err := f.generatePayloadAttributes(sequencerTxs)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate payload attributes")
 	}
@@ -252,7 +286,7 @@ func (f *SequencerConsensusClient) Propose(ctx context.Context, blockMetrics *me
 	transactionsPerBlock := len(payload.Transactions)
 	blockMetrics.AddExecutionMetric(metrics.TransactionsPerBlockMetric, transactionsPerBlock)
 
-	err = f.newPayload(ctx, payload)
+	err = f.newPayload(ctx, payload, *beaconRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/runner/network/consensus/validator_consensus.go
+++ b/runner/network/consensus/validator_consensus.go
@@ -2,12 +2,14 @@ package consensus
 
 import (
 	"context"
+	"math/big"
 	"time"
 
 	"github.com/base/base-bench/runner/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -28,21 +30,18 @@ func NewSyncingConsensusClient(log log.Logger, client *ethclient.Client, authCli
 // Propose starts block generation, waits BlockTime, and generates a block.
 func (f *SyncingConsensusClient) propose(ctx context.Context, payload *engine.ExecutableData, blockMetrics *metrics.BlockMetrics) error {
 	f.log.Info("Updating fork choice before validating payload", "payload_index", payload.Number)
-	startTime := time.Now()
-	_, err := f.updateForkChoice(ctx, nil)
-	if err != nil {
-		return err
-	}
-	duration := time.Since(startTime)
-	blockMetrics.AddExecutionMetric(metrics.UpdateForkChoiceLatencyMetric, duration)
+
+	root := crypto.Keccak256Hash([]byte("fake-beacon-block-root"), big.NewInt(1).Bytes())
 
 	f.log.Info("Validate payload", "payload_index", payload.Number)
-	startTime = time.Now()
-	err = f.newPayload(ctx, payload)
+	startTime := time.Now()
+	err := f.newPayload(ctx, payload, root)
 	if err != nil {
 		return err
 	}
-	duration = time.Since(startTime)
+
+	f.headBlockHash = payload.BlockHash
+	duration := time.Since(startTime)
 	f.log.Info("Validated payload", "payload_index", payload.Number, "duration", duration)
 	blockMetrics.AddExecutionMetric(metrics.NewPayloadLatencyMetric, duration)
 
@@ -52,6 +51,14 @@ func (f *SyncingConsensusClient) propose(ctx context.Context, payload *engine.Ex
 
 	blockMetrics.AddExecutionMetric(metrics.GasPerBlockMetric, float64(gasUsed))
 	blockMetrics.AddExecutionMetric(metrics.GasPerSecondMetric, gasPerSecond)
+
+	startTime = time.Now()
+	_, err = f.updateForkChoice(ctx, nil)
+	if err != nil {
+		return err
+	}
+	duration = time.Since(startTime)
+	blockMetrics.AddExecutionMetric(metrics.UpdateForkChoiceLatencyMetric, duration)
 
 	return nil
 }

--- a/runner/network/fault_proof_benchmark.go
+++ b/runner/network/fault_proof_benchmark.go
@@ -1,0 +1,238 @@
+package network
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/base/base-bench/runner/logger"
+	"github.com/base/base-bench/runner/network/configutil"
+	"github.com/base/base-bench/runner/network/proofprogram"
+	"github.com/base/base-bench/runner/network/proofprogram/fakel1"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/pkg/errors"
+)
+
+type ProofProgramBenchmark interface {
+	Run(ctx context.Context, payloads []engine.ExecutableData, firstTestBlock uint64) error
+}
+
+type opProgramBenchmark struct {
+	l2Genesis    *core.Genesis
+	log          log.Logger
+	opProgramBin string
+	l2RPCURL     string
+	chain        fakel1.L1Chain
+	batcher      *proofprogram.Batcher
+	rollupCfg    *rollup.Config
+}
+
+func NewOPProgramBenchmark(genesis *core.Genesis, log log.Logger, opProgramBin string, l2RPCURL string, l1Chain fakel1.L1Chain, batcherKey *ecdsa.PrivateKey) ProofProgramBenchmark {
+	rollupCfg := configutil.GetRollupConfig(genesis, l1Chain, crypto.PubkeyToAddress(batcherKey.PublicKey))
+	batcher := proofprogram.NewBatcher(rollupCfg, batcherKey, l1Chain)
+
+	return &opProgramBenchmark{
+		l2Genesis:    genesis,
+		log:          log,
+		opProgramBin: opProgramBin,
+		l2RPCURL:     l2RPCURL,
+		chain:        l1Chain,
+		rollupCfg:    rollupCfg,
+		batcher:      batcher,
+	}
+}
+
+func (o *opProgramBenchmark) Run(ctx context.Context, payloads []engine.ExecutableData, firstTestBlock uint64) error {
+	// Split payloads into setup and test groups
+	setupPayloads := make([]engine.ExecutableData, firstTestBlock)
+	copy(setupPayloads, payloads[:firstTestBlock])
+	testPayloads := payloads[firstTestBlock:]
+
+	// Process batches
+	if err := o.processBatches(setupPayloads, testPayloads); err != nil {
+		return err
+	}
+
+	// Start L1 proxy server
+	l1Proxy := fakel1.NewL1ProxyServer(o.log, 8099, o.chain)
+	if err := l1Proxy.Run(ctx); err != nil {
+		return fmt.Errorf("failed to start l1 proxy: %w", err)
+	}
+	defer l1Proxy.Stop()
+
+	// Connect to L2 RPC and get block information
+	ethClient, err := o.connectToL2RPC(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Prepare for op-program execution
+	l2HeadNumber := testPayloads[len(testPayloads)-1].Number
+	blockBeforeL2Head, l2OutputRoot, claimOutputRoot, err := o.prepareBlockData(ctx, ethClient, l2HeadNumber)
+	if err != nil {
+		return err
+	}
+
+	// Write necessary files
+	if err := o.writeConfigFiles(); err != nil {
+		return err
+	}
+
+	// Execute op-program
+	return o.executeOpProgram(ctx, blockBeforeL2Head, l2HeadNumber, l2OutputRoot, claimOutputRoot)
+}
+
+// processBatches creates and sends both setup and test batches
+func (o *opProgramBenchmark) processBatches(setupPayloads, testPayloads []engine.ExecutableData) error {
+	// Process setup batches
+	parentHash, err := o.chain.GetLatestBlock()
+	if err != nil {
+		return fmt.Errorf("failed to get parent hash: %w", err)
+	}
+
+	if err := o.batcher.CreateAndSendBatch(setupPayloads, parentHash.Hash()); err != nil {
+		return fmt.Errorf("failed to create span batch for setup: %w", err)
+	}
+
+	// Process test batches
+	parentHash, err = o.chain.GetLatestBlock()
+	if err != nil {
+		return fmt.Errorf("failed to get parent hash: %w", err)
+	}
+
+	if err := o.batcher.CreateAndSendBatch(testPayloads, parentHash.Hash()); err != nil {
+		return fmt.Errorf("failed to create span batch for test: %w", err)
+	}
+
+	return nil
+}
+
+// connectToL2RPC establishes a connection to the L2 RPC endpoint
+func (o *opProgramBenchmark) connectToL2RPC(ctx context.Context) (*ethclient.Client, error) {
+	o.log.Info("Dialing L2 RPC", "url", o.l2RPCURL)
+
+	rpcClient, err := rpc.DialOptions(ctx, o.l2RPCURL, rpc.WithHTTPClient(&http.Client{
+		Timeout: 30 * time.Second,
+	}))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to dial rpc")
+	}
+
+	return ethclient.NewClient(rpcClient), nil
+}
+
+// prepareBlockData fetches necessary block data for op-program execution
+func (o *opProgramBenchmark) prepareBlockData(ctx context.Context, ethClient *ethclient.Client, l2HeadNumber uint64) (*types.Header, eth.Bytes32, eth.Bytes32, error) {
+	// Fetch latest L2 block
+	latestL2Block, err := ethClient.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return nil, eth.Bytes32{}, eth.Bytes32{}, fmt.Errorf("failed to get latest l2 block: %w", err)
+	}
+	o.log.Info("Latest L2 block", "number", latestL2Block.Number, "hash", latestL2Block.Hash().Hex())
+
+	// Get block before L2 head
+	blockBeforeL2Head, err := ethClient.HeaderByNumber(ctx, big.NewInt(int64(l2HeadNumber-1)))
+	if err != nil {
+		return nil, eth.Bytes32{}, eth.Bytes32{}, fmt.Errorf("failed to get block before l2 head %d: %w", big.NewInt(int64(l2HeadNumber-1)), err)
+	}
+
+	// Calculate L2 output root
+	l2OutputRoot := eth.OutputRoot(&eth.OutputV0{
+		StateRoot:                eth.Bytes32(blockBeforeL2Head.Root),
+		BlockHash:                blockBeforeL2Head.Hash(),
+		MessagePasserStorageRoot: eth.Bytes32(blockBeforeL2Head.WithdrawalsHash.Bytes()),
+	})
+
+	// Get expected claim block
+	expectedClaimBlock, err := ethClient.BlockByNumber(ctx, big.NewInt(int64(l2HeadNumber)))
+	if err != nil {
+		return nil, eth.Bytes32{}, eth.Bytes32{}, fmt.Errorf("failed to get expected claim block %d: %w", l2HeadNumber, err)
+	}
+
+	if expectedClaimBlock == nil {
+		return nil, eth.Bytes32{}, eth.Bytes32{}, fmt.Errorf("expected claim block %d not found", l2HeadNumber)
+	}
+
+	// Calculate claim output root
+	claimOutputRoot := eth.OutputRoot(&eth.OutputV0{
+		StateRoot:                eth.Bytes32(expectedClaimBlock.Root()),
+		BlockHash:                expectedClaimBlock.Hash(),
+		MessagePasserStorageRoot: eth.Bytes32(*expectedClaimBlock.WithdrawalsRoot()),
+	})
+
+	return blockBeforeL2Head, l2OutputRoot, claimOutputRoot, nil
+}
+
+// writeConfigFiles writes necessary configuration files to disk
+func (o *opProgramBenchmark) writeConfigFiles() error {
+	// Write rollup.json
+	rollupFile, err := os.Create("rollup.json")
+	if err != nil {
+		return fmt.Errorf("failed to create rollup.json: %w", err)
+	}
+	defer func() { _ = rollupFile.Close() }()
+
+	if err = json.NewEncoder(rollupFile).Encode(o.rollupCfg); err != nil {
+		return fmt.Errorf("failed to encode rollup.json: %w", err)
+	}
+
+	return nil
+}
+
+// executeOpProgram runs the op-program binary with the necessary arguments
+func (o *opProgramBenchmark) executeOpProgram(ctx context.Context, blockBeforeL2Head *types.Header, l2HeadNumber uint64, l2OutputRoot, claimOutputRoot eth.Bytes32) error {
+	l1Head, err := o.chain.GetBlockByNumber(3)
+	if err != nil {
+		return fmt.Errorf("failed to get l1 head: %w", err)
+	}
+
+	// Start op-program
+	cmd := exec.CommandContext(ctx, o.opProgramBin,
+		"--l1", "http://127.0.0.1:8099",
+		"--l1.beacon", "http://127.0.0.1:8099",
+		"--l2", o.l2RPCURL,
+		"--l1.head", l1Head.Hash().Hex(),
+		"--l2.head", blockBeforeL2Head.Hash().Hex(),
+		"--l2.outputroot", common.Hash(l2OutputRoot).Hex(),
+		"--l2.blocknumber", fmt.Sprintf("%d", l2HeadNumber),
+		"--l2.claim", common.Hash(claimOutputRoot).Hex(),
+		"--l2.genesis", "genesis.json",
+		"--rollup.config", "rollup.json",
+	)
+
+	cmd.Stdout = logger.NewLogWriterWithLevel(o.log, slog.LevelInfo)
+	cmd.Stderr = logger.NewLogWriterWithLevel(o.log, slog.LevelInfo)
+
+	if err = cmd.Run(); err != nil {
+		o.logFailureDetails(l2HeadNumber, blockBeforeL2Head, claimOutputRoot, l2OutputRoot)
+		return fmt.Errorf("failed to run op-program: %w", err)
+	}
+
+	return nil
+}
+
+// logFailureDetails logs detailed information when op-program execution fails
+func (o *opProgramBenchmark) logFailureDetails(l2HeadNumber uint64, blockBeforeL2Head *types.Header, claimOutputRoot, l2OutputRoot eth.Bytes32) {
+	o.log.Info("op-program execution failed",
+		"l2HeadNumber", l2HeadNumber,
+		"blockBeforeL2Head", blockBeforeL2Head.Hash().Hex(),
+		"claimOutputRoot", common.Hash(claimOutputRoot).Hex(),
+		"l2OutputRoot", common.Hash(l2OutputRoot).Hex(),
+	)
+}

--- a/runner/network/l1_chain.go
+++ b/runner/network/l1_chain.go
@@ -1,0 +1,102 @@
+package network
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"path"
+	"time"
+
+	"github.com/base/base-bench/runner/network/proofprogram/fakel1"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+type l1Chain struct {
+	chain fakel1.L1Chain
+}
+
+func newL1Chain(config *TestConfig) (*l1Chain, error) {
+	chain, err := setupChain(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup L1 chain: %w", err)
+	}
+
+	return &l1Chain{
+		chain: chain,
+	}, nil
+}
+
+func makeL1Genesis(prefundAddr []common.Address) core.Genesis {
+	zero := uint64(0)
+	alloc := make(ethTypes.GenesisAlloc)
+	for _, addr := range prefundAddr {
+		alloc[addr] = ethTypes.Account{
+			Balance: new(big.Int).Mul(big.NewInt(1e6), big.NewInt(params.Ether)),
+		}
+	}
+	blobSchedule := *params.DefaultBlobSchedule
+	l1Genesis := core.Genesis{
+		Config: &params.ChainConfig{
+			ChainID:             big.NewInt(1),
+			HomesteadBlock:      big.NewInt(0),
+			DAOForkBlock:        nil,
+			DAOForkSupport:      false,
+			EIP150Block:         big.NewInt(0),
+			EIP155Block:         big.NewInt(0),
+			EIP158Block:         big.NewInt(0),
+			ByzantiumBlock:      big.NewInt(0),
+			ConstantinopleBlock: big.NewInt(0),
+			PetersburgBlock:     big.NewInt(0),
+			IstanbulBlock:       big.NewInt(0),
+			MuirGlacierBlock:    big.NewInt(0),
+			BerlinBlock:         big.NewInt(0),
+			LondonBlock:         big.NewInt(0),
+			ArrowGlacierBlock:   big.NewInt(0),
+			GrayGlacierBlock:    big.NewInt(0),
+			ShanghaiTime:        &zero,
+			CancunTime:          &zero,
+			PragueTime:          &zero,
+			// To enable post-Merge consensus at genesis
+			MergeNetsplitBlock:      big.NewInt(0),
+			TerminalTotalDifficulty: big.NewInt(0),
+			// use default Ethereum prod blob schedules
+			BlobScheduleConfig: &blobSchedule,
+		},
+		Nonce:      0,
+		Alloc:      alloc,
+		Timestamp:  0, // blocks will have better timestamps
+		ExtraData:  []byte{},
+		GasLimit:   30_000_000,
+		Difficulty: big.NewInt(0),
+		Mixhash:    common.Hash{},
+		Coinbase:   common.Address{},
+		BaseFee:    big.NewInt(1e9),
+	}
+
+	return l1Genesis
+}
+
+func setupChain(config *TestConfig) (fakel1.L1Chain, error) {
+	blobsFolder := path.Join(config.Config.DataDir(), "blobs")
+	if err := os.MkdirAll(blobsFolder, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create blobs folder: %w", err)
+	}
+
+	prefundAccts := []common.Address{
+		config.BatcherAddr(),
+	}
+
+	// use current time as the timestamp to base the L1 chain on
+	l1Genesis := makeL1Genesis(prefundAccts)
+	l2FirstBlockTime := uint64(time.Now().Add(-time.Minute).Unix())
+
+	chain, err := fakel1.NewFakeL1ChainWithGenesis(blobsFolder, &l1Genesis, l2FirstBlockTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make chain: %w", err)
+	}
+
+	return chain, nil
+}

--- a/runner/network/sequencer_benchmark.go
+++ b/runner/network/sequencer_benchmark.go
@@ -1,0 +1,279 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/base/base-bench/runner/clients/types"
+	"github.com/base/base-bench/runner/metrics"
+	"github.com/base/base-bench/runner/network/consensus"
+	"github.com/base/base-bench/runner/network/mempool"
+	"github.com/base/base-bench/runner/network/proofprogram/fakel1"
+	"github.com/base/base-bench/runner/payload"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/pkg/errors"
+)
+
+type sequencerBenchmark struct {
+	log             log.Logger
+	sequencerClient types.ExecutionClient
+	config          TestConfig
+	l1Chain         *l1Chain
+}
+
+func newSequencerBenchmark(log log.Logger, config TestConfig, sequencerClient types.ExecutionClient, l1Chain *l1Chain) *sequencerBenchmark {
+	return &sequencerBenchmark{
+		log:             log,
+		config:          config,
+		sequencerClient: sequencerClient,
+		l1Chain:         l1Chain,
+	}
+}
+
+func (nb *sequencerBenchmark) fundTestAccount(ctx context.Context, mempool mempool.FakeMempool, sequencerClient types.ExecutionClient, amount *big.Int) error {
+	nb.log.Info("Funding test account")
+	client := sequencerClient
+
+	// private key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+
+	// fund the test account if needed (check if the account has a balance)
+	balance, err := client.Client().BalanceAt(ctx, addr, nil)
+	if err != nil {
+		nb.log.Warn("failed to get balance", "err", err)
+		return err
+	}
+
+	blockNumber := uint64(0)
+	blockHeader, err := client.Client().HeaderByNumber(ctx, nil)
+	if err != nil {
+		nb.log.Warn("failed to get block header", "err", err)
+		return err
+	}
+	blockNumber = blockHeader.Number.Uint64()
+
+	random := rand.New(rand.NewSource(int64(blockNumber)))
+	randomHash := common.BigToHash(big.NewInt(random.Int63()))
+
+	// if balance is already good, return
+	if balance.Cmp(amount) >= 0 {
+		return nil
+	}
+
+	depositTx := ethTypes.NewTx(
+		&ethTypes.DepositTx{
+			From:                common.Address{1},
+			To:                  &addr,
+			SourceHash:          randomHash,
+			IsSystemTransaction: false,
+			Mint:                amount,
+			Value:               amount,
+			Gas:                 210000,
+			Data:                []byte{},
+		},
+	)
+
+	txHash := depositTx.Hash()
+
+	mempool.AddTransactions([]*ethTypes.Transaction{depositTx})
+
+	// wait for the transaction to be mined
+	receipt, err := retry.Do(ctx, 60, retry.Fixed(1*time.Second), func() (*ethTypes.Receipt, error) {
+		receipt, err := client.Client().TransactionReceipt(ctx, txHash)
+		if err != nil {
+			return nil, err
+		}
+		return receipt, nil
+	})
+	if receipt == nil {
+		return fmt.Errorf("failed to get transaction receipt: %w", err)
+	}
+	nb.log.Info("Included deposit tx in block", "block", receipt.BlockNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction receipt: %w", err)
+	}
+	if receipt.Status != 1 {
+		return fmt.Errorf("transaction failed with status: %d", receipt.Status)
+	}
+
+	// ensure balance
+	balance, err = client.Client().BalanceAt(ctx, addr, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get balance: %w", err)
+	}
+	if balance.Cmp(amount) < 0 {
+		nb.log.Warn("balance is not equal to amount", "balance", balance, "amount", amount)
+		return errors.New("balance is not equal to amount")
+	}
+	nb.log.Info("funded test account", "balance", balance, "account", addr.Hex())
+
+	return nil
+}
+
+func (nb *sequencerBenchmark) Run(ctx context.Context, metricsCollector metrics.MetricsCollector) ([]engine.ExecutableData, uint64, error) {
+	amount := new(big.Int).Mul(big.NewInt(1e6), big.NewInt(params.Ether))
+	privateKey := common.FromHex("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+
+	var mempool mempool.FakeMempool
+	var worker payload.Worker
+	var err error
+
+	params := nb.config.Params
+	config := nb.config.Config
+	genesis := nb.config.Genesis
+
+	payloadType := params.TransactionPayload
+	sequencerClient := nb.sequencerClient
+
+	switch {
+	case payloadType == "tx-fuzz":
+		nb.log.Info("Running tx-fuzz payload")
+		mempool, worker, err = payload.NewTxFuzzPayloadWorker(
+			nb.log, sequencerClient.ClientURL(), params, privateKey, amount, config.TxFuzzBinary())
+	case payloadType == "transfer-only":
+		mempool, worker, err = payload.NewTransferPayloadWorker(
+			ctx, nb.log, sequencerClient.ClientURL(), params, privateKey, amount, &genesis)
+	case strings.HasPrefix(string(payloadType), "contract"):
+		var payloadConfig payload.ContractPayloadWorkerConfig
+		payloadConfig, err = payload.ValidateContractPayload(payloadType, config.ConfigPath())
+		if err != nil {
+			return nil, 0, err
+		}
+
+		mempool, worker, err = payload.NewContractPayloadWorker(
+			nb.log, sequencerClient.ClientURL(), params, privateKey, amount, payloadConfig, &genesis)
+	default:
+		return nil, 0, errors.New("invalid payload type")
+	}
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	defer func() {
+		err := worker.Stop(ctx)
+		if err != nil {
+			nb.log.Warn("failed to stop payload worker", "err", err)
+		}
+	}()
+
+	benchmarkCtx, benchmarkCancel := context.WithCancel(ctx)
+	defer benchmarkCancel()
+
+	errChan := make(chan error)
+	payloadResult := make(chan []engine.ExecutableData)
+
+	setupComplete := make(chan struct{})
+
+	go func() {
+		err := nb.fundTestAccount(benchmarkCtx, mempool, sequencerClient, amount)
+		if err != nil {
+			nb.log.Warn("failed to fund test account", "err", err)
+			errChan <- err
+			return
+		}
+
+		err = worker.Setup(benchmarkCtx)
+		if err != nil {
+			nb.log.Warn("failed to setup payload worker", "err", err)
+			errChan <- err
+			return
+		}
+		close(setupComplete)
+	}()
+
+	var lastSetupBlock uint64
+
+	headBlockHeader, err := sequencerClient.Client().HeaderByNumber(ctx, nil)
+	if err != nil {
+		nb.log.Warn("failed to get head block header", "err", err)
+		return nil, 0, err
+	}
+	headBlockHash := headBlockHeader.Hash()
+	headBlockNumber := headBlockHeader.Number.Uint64()
+
+	var l1Chain fakel1.L1Chain
+	if nb.l1Chain != nil {
+		l1Chain = nb.l1Chain.chain
+	}
+
+	go func() {
+		consensusClient := consensus.NewSequencerConsensusClient(nb.log, sequencerClient.Client(), sequencerClient.AuthClient(), mempool, consensus.ConsensusClientOptions{
+			BlockTime: params.BlockTime,
+			GasLimit:  params.GasLimit,
+		}, headBlockHash, headBlockNumber, l1Chain, nb.config.BatcherAddr())
+
+		payloads := make([]engine.ExecutableData, 0)
+
+		// setup blocks
+		blockNum := uint64(0)
+
+	setupLoop:
+		for {
+			_blockMetrics := metrics.NewBlockMetrics(blockNum)
+			payload, err := consensusClient.Propose(benchmarkCtx, _blockMetrics)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			payloads = append(payloads, *payload)
+			blockNum = payload.Number
+			select {
+			case <-setupComplete:
+				break setupLoop
+			default:
+			}
+		}
+
+		lastSetupBlock = payloads[len(payloads)-1].Number
+		nb.log.Info("Last setup block", "block", lastSetupBlock)
+
+		// run for a few blocks
+		for i := 0; i < params.NumBlocks; i++ {
+			blockMetrics := metrics.NewBlockMetrics(uint64(i))
+			err := worker.SendTxs(benchmarkCtx)
+			if err != nil {
+				nb.log.Warn("failed to send transactions", "err", err)
+				errChan <- err
+				return
+			}
+
+			payload, err := consensusClient.Propose(benchmarkCtx, blockMetrics)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			if payload == nil {
+				errChan <- errors.New("received nil payload from consensus client")
+				return
+			}
+
+			time.Sleep(1000 * time.Millisecond)
+
+			err = metricsCollector.Collect(benchmarkCtx, blockMetrics)
+			if err != nil {
+				nb.log.Error("Failed to collect metrics", "error", err)
+			}
+			payloads = append(payloads, *payload)
+		}
+		payloadResult <- payloads
+	}()
+
+	select {
+	case err := <-errChan:
+		return nil, 0, err
+	case payloads := <-payloadResult:
+		return payloads, lastSetupBlock + 1, nil
+	}
+}

--- a/runner/network/validator_benchmark.go
+++ b/runner/network/validator_benchmark.go
@@ -1,0 +1,93 @@
+package network
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/base/base-bench/runner/benchmark"
+	"github.com/base/base-bench/runner/clients/types"
+	"github.com/base/base-bench/runner/metrics"
+	"github.com/base/base-bench/runner/network/consensus"
+	"github.com/base/base-bench/runner/network/proofprogram/fakel1"
+
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/pkg/errors"
+)
+
+type validatorBenchmark struct {
+	log             log.Logger
+	validatorClient types.ExecutionClient
+	config          TestConfig
+	proofConfig     *benchmark.ProofProgramOptions
+	l1Chain         *l1Chain
+}
+
+func newValidatorBenchmark(log log.Logger, config TestConfig, validatorClient types.ExecutionClient, l1Chain *l1Chain, proofConfig *benchmark.ProofProgramOptions) *validatorBenchmark {
+	return &validatorBenchmark{
+		log:             log,
+		config:          config,
+		validatorClient: validatorClient,
+		proofConfig:     proofConfig,
+		l1Chain:         l1Chain,
+	}
+}
+
+func (vb *validatorBenchmark) benchmarkFaultProofProgram(ctx context.Context, payloads []engine.ExecutableData, firstTestBlock uint64, l1Chain fakel1.L1Chain, batcherKey *ecdsa.PrivateKey) error {
+	version := vb.proofConfig.Version
+	if version == "" {
+		return fmt.Errorf("proof_program.version is not set")
+	}
+
+	// ensure binary exists
+	binaryPath := path.Join("op-program", "versions", version, "op-program")
+	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+		return fmt.Errorf("proof program binary does not exist at %s", binaryPath)
+	}
+
+	opProgramBenchmark := NewOPProgramBenchmark(&vb.config.Genesis, vb.log, binaryPath, vb.validatorClient.ClientURL(), l1Chain, batcherKey)
+
+	return opProgramBenchmark.Run(ctx, payloads, firstTestBlock)
+}
+
+func (vb *validatorBenchmark) Run(ctx context.Context, payloads []engine.ExecutableData, firstTestBlock uint64, metricsCollector metrics.MetricsCollector) error {
+	headBlockHeader, err := vb.validatorClient.Client().HeaderByNumber(ctx, nil)
+	if err != nil {
+		vb.log.Warn("failed to get head block header", "err", err)
+		return err
+	}
+	headBlockHash := headBlockHeader.Hash()
+	headBlockNumber := headBlockHeader.Number.Uint64()
+
+	consensusClient := consensus.NewSyncingConsensusClient(vb.log, vb.validatorClient.Client(), vb.validatorClient.AuthClient(), consensus.ConsensusClientOptions{
+		BlockTime: vb.config.Params.BlockTime,
+	}, headBlockHash, headBlockNumber)
+
+	err = consensusClient.Start(ctx, payloads, metricsCollector, firstTestBlock)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		vb.log.Warn("failed to run consensus client", "err", err)
+		return err
+	}
+
+	if vb.proofConfig == nil {
+		vb.log.Info("Skipping fault proof program benchmark as it is not enabled")
+		return nil
+	}
+
+	if vb.l1Chain == nil {
+		return fmt.Errorf("l1 chain should be setup if fault proof program is enabled")
+	}
+
+	err = vb.benchmarkFaultProofProgram(ctx, payloads, firstTestBlock, vb.l1Chain.chain, &vb.config.BatcherKey)
+	if err != nil {
+		return fmt.Errorf("failed to run fault proof program: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

This PR splits up the network benchmark into three simple phases:
- Sequencer benchmark - benchmarks building new blocks with geth/reth/rbuilder
- Validator benchmark - benchmarks validating the built blocks with geth/reth
- Proof program benchmark - benchmarks proving a block in the testing payload with op-program (and in the future Kona/etc). This also somewhat covers `op-node` which uses `op-program` under the hood.

Updates L1BlockInfo to include actual info from the fake L1 which tells op-program how to read data relevant to proving each block.

Sets fee recipient to the expected Optimism fee vault, includes same beacon root as L1 as required by Ecotone.

Moves common test config to a single struct so we can easily add/remove available info. https://github.com/base/benchmark/pull/73/files#diff-1cb9d43c8e00a62b1e93cee975b5f1a564335c1a1049a3fd4678c27a320916adR31-R38

# Testing

<!-- How was the code in this PR tested? -->

Tested that the benchmark successfully completes.