### PR TITLE
chore: refactor transaction workload directory structure

### DIFF
--- a/runner/network/l1_chain.go
+++ b/runner/network/l1_chain.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/base/base-bench/runner/network/proofprogram/fakel1"
+	"github.com/base/base-bench/runner/network/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -18,7 +19,7 @@ type l1Chain struct {
 	chain fakel1.L1Chain
 }
 
-func newL1Chain(config *TestConfig) (*l1Chain, error) {
+func newL1Chain(config *types.TestConfig) (*l1Chain, error) {
 	chain, err := setupChain(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup L1 chain: %w", err)
@@ -79,7 +80,7 @@ func makeL1Genesis(prefundAddr []common.Address) core.Genesis {
 	return l1Genesis
 }
 
-func setupChain(config *TestConfig) (fakel1.L1Chain, error) {
+func setupChain(config *types.TestConfig) (fakel1.L1Chain, error) {
 	blobsFolder := path.Join(config.Config.DataDir(), "blobs")
 	if err := os.MkdirAll(blobsFolder, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create blobs folder: %w", err)

--- a/runner/network/network_benchmark.go
+++ b/runner/network/network_benchmark.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"fmt"
 	"os"
 	"path"
@@ -15,10 +14,8 @@ import (
 	"github.com/base/base-bench/runner/logger"
 	"github.com/base/base-bench/runner/metrics"
 
+	benchtypes "github.com/base/base-bench/runner/network/types"
 	"github.com/ethereum/go-ethereum/beacon/engine"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/pkg/errors"
 )
@@ -26,25 +23,6 @@ import (
 const (
 	ExecutionLayerLogFileName = "el.log"
 )
-
-// TestConfig holds all configuration needed for a benchmark test
-type TestConfig struct {
-	Params     benchmark.Params
-	Config     config.Config
-	Genesis    core.Genesis
-	BatcherKey ecdsa.PrivateKey
-	// BatcherAddr is lazily initialized to avoid unnecessary computation
-	batcherAddr *common.Address
-}
-
-// BatcherAddr returns the batcher address, computing it if necessary
-func (c *TestConfig) BatcherAddr() common.Address {
-	if c.batcherAddr == nil {
-		batcherAddr := crypto.PubkeyToAddress(c.BatcherKey.PublicKey)
-		c.batcherAddr = &batcherAddr
-	}
-	return *c.batcherAddr
-}
 
 // NetworkBenchmark handles the lifecycle for a single benchmark run
 type NetworkBenchmark struct {
@@ -56,12 +34,12 @@ type NetworkBenchmark struct {
 	collectedSequencerMetrics *benchmark.SequencerKeyMetrics
 	collectedValidatorMetrics *benchmark.ValidatorKeyMetrics
 
-	testConfig  *TestConfig
+	testConfig  *benchtypes.TestConfig
 	proofConfig *benchmark.ProofProgramOptions
 }
 
 // NewNetworkBenchmark creates a new network benchmark and initializes the payload worker and consensus client
-func NewNetworkBenchmark(config *TestConfig, log log.Logger, sequencerOptions *config.InternalClientOptions, validatorOptions *config.InternalClientOptions, proofConfig *benchmark.ProofProgramOptions) (*NetworkBenchmark, error) {
+func NewNetworkBenchmark(config *benchtypes.TestConfig, log log.Logger, sequencerOptions *config.InternalClientOptions, validatorOptions *config.InternalClientOptions, proofConfig *benchmark.ProofProgramOptions) (*NetworkBenchmark, error) {
 	return &NetworkBenchmark{
 		log:              log,
 		sequencerOptions: sequencerOptions,

--- a/runner/network/types/types.go
+++ b/runner/network/types/types.go
@@ -1,7 +1,15 @@
 package types
 
 import (
+	"crypto/ecdsa"
+	"math/big"
+
+	"github.com/base/base-bench/runner/benchmark"
+	"github.com/base/base-bench/runner/config"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 // BasicBlockType implements what chain config would usually implement.
@@ -18,3 +26,25 @@ func (b IsthmusBlockType) IsIsthmus(blkTime uint64) bool {
 }
 
 var _ ethTypes.BlockType = IsthmusBlockType{}
+
+// TestConfig holds all configuration needed for a benchmark test
+type TestConfig struct {
+	Params     benchmark.Params
+	Config     config.Config
+	Genesis    core.Genesis
+	BatcherKey ecdsa.PrivateKey
+	// BatcherAddr is lazily initialized to avoid unnecessary computation
+	batcherAddr *common.Address
+
+	PrefundPrivateKey ecdsa.PrivateKey
+	PrefundAmount     big.Int
+}
+
+// BatcherAddr returns the batcher address, computing it if necessary
+func (c *TestConfig) BatcherAddr() common.Address {
+	if c.batcherAddr == nil {
+		batcherAddr := crypto.PubkeyToAddress(c.BatcherKey.PublicKey)
+		c.batcherAddr = &batcherAddr
+	}
+	return *c.batcherAddr
+}

--- a/runner/network/validator_benchmark.go
+++ b/runner/network/validator_benchmark.go
@@ -12,6 +12,7 @@ import (
 	"github.com/base/base-bench/runner/metrics"
 	"github.com/base/base-bench/runner/network/consensus"
 	"github.com/base/base-bench/runner/network/proofprogram/fakel1"
+	benchtypes "github.com/base/base-bench/runner/network/types"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/log"
@@ -21,12 +22,12 @@ import (
 type validatorBenchmark struct {
 	log             log.Logger
 	validatorClient types.ExecutionClient
-	config          TestConfig
+	config          benchtypes.TestConfig
 	proofConfig     *benchmark.ProofProgramOptions
 	l1Chain         *l1Chain
 }
 
-func newValidatorBenchmark(log log.Logger, config TestConfig, validatorClient types.ExecutionClient, l1Chain *l1Chain, proofConfig *benchmark.ProofProgramOptions) *validatorBenchmark {
+func newValidatorBenchmark(log log.Logger, config benchtypes.TestConfig, validatorClient types.ExecutionClient, l1Chain *l1Chain, proofConfig *benchmark.ProofProgramOptions) *validatorBenchmark {
 	return &validatorBenchmark{
 		log:             log,
 		config:          config,

--- a/runner/payload/factory.go
+++ b/runner/payload/factory.go
@@ -1,0 +1,45 @@
+package payload
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/base/base-bench/runner/benchmark"
+	clienttypes "github.com/base/base-bench/runner/clients/types"
+	benchtypes "github.com/base/base-bench/runner/network/types"
+	"github.com/base/base-bench/runner/payload/contract"
+	"github.com/base/base-bench/runner/payload/transferonly"
+	"github.com/base/base-bench/runner/payload/txfuzz"
+	"github.com/base/base-bench/runner/payload/worker"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func NewPayloadWorker(ctx context.Context, log log.Logger, testConfig *benchtypes.TestConfig, sequencerClient clienttypes.ExecutionClient, payloadType benchmark.TransactionPayload) (worker.Worker, error) {
+	config := testConfig.Config
+	genesis := testConfig.Genesis
+
+	params := testConfig.Params
+
+	privateKey := testConfig.PrefundPrivateKey
+	amount := &testConfig.PrefundAmount
+
+	var worker worker.Worker
+	var err error
+
+	switch {
+	case payloadType == "tx-fuzz":
+		worker, err = txfuzz.NewTxFuzzPayloadWorker(
+			log, sequencerClient.ClientURL(), params, privateKey, amount, config.TxFuzzBinary())
+	case payloadType == "transfer-only":
+		worker, err = transferonly.NewTransferPayloadWorker(
+			ctx, log, sequencerClient.ClientURL(), params, privateKey, amount, &genesis)
+	case strings.HasPrefix(string(payloadType), "contract"):
+		worker, err = contract.NewContractPayloadWorker(
+			log, sequencerClient.ClientURL(), params, privateKey, amount, &genesis, payloadType, config)
+	default:
+		return nil, errors.New("invalid payload type")
+	}
+
+	return worker, err
+}

--- a/runner/payload/worker/types.go
+++ b/runner/payload/worker/types.go
@@ -1,0 +1,20 @@
+package worker
+
+import (
+	"context"
+	"log"
+	"math/big"
+
+	"github.com/base/base-bench/runner/benchmark"
+	"github.com/base/base-bench/runner/network/mempool"
+)
+
+// Note: Payload workers are responsible keeping track of gas in a block and sending transactions to the mempool.
+type Worker interface {
+	Setup(ctx context.Context) error
+	SendTxs(ctx context.Context) error
+	Stop(ctx context.Context) error
+	Mempool() mempool.FakeMempool
+}
+
+type NewWorkerFn func(logger log.Logger, elRPCURL string, params benchmark.Params, prefundedPrivateKey []byte, prefundAmount *big.Int) (Worker, error)


### PR DESCRIPTION
# Description

This PR looks pretty big, but is mainly just renaming and moving around code.

Organize transaction workload generator interface to separate packages and move the initialization to a factory method.

This ensures we have a consistent interface for creating transaction workloads. This PR also makes all the payload generators private so only the public interface is exported.

# Testing

<!-- How was the code in this PR tested? -->

CI testing should cover this.
