### PR TITLE
fix: improve reliability of long runs

### DIFF
--- a/benchmark/cmd/main.go
+++ b/benchmark/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 	app.Flags = flags.Flags
 	app.Version = opservice.FormatVersion(Version, GitCommit, GitDate, "")
 
-	ctx := ctxinterrupt.WithSignalWaiterMain(context.Background())
+	ctx := ctxinterrupt.WithCancelOnInterrupt(context.Background())
 	err := app.RunContext(ctx, os.Args)
 	if err != nil {
 		log.Crit("Application failed", "message", err)

--- a/runner/benchmark/benchmark.go
+++ b/runner/benchmark/benchmark.go
@@ -25,7 +25,7 @@ type TestRun struct {
 
 const (
 	// MaxTotalParams is the maximum number of benchmarks that can be run in parallel.
-	MaxTotalParams = 24
+	MaxTotalParams = 100
 )
 
 var DefaultParams = &types.RunParams{

--- a/runner/benchmark/result_metadata.go
+++ b/runner/benchmark/result_metadata.go
@@ -20,6 +20,7 @@ type CommonKeyMetrics struct {
 
 type BenchmarkRunResult struct {
 	Success          bool                `json:"success"`
+	Complete         bool                `json:"complete"`
 	SequencerMetrics SequencerKeyMetrics `json:"sequencerMetrics"`
 	ValidatorMetrics ValidatorKeyMetrics `json:"validatorMetrics"`
 }

--- a/runner/clients/common/wait.go
+++ b/runner/clients/common/wait.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	RPCTimeout    = 60 * time.Second
+	RPCTimeout    = 240 * time.Second
 	RetryInterval = time.Second
 )
 

--- a/runner/clients/geth/client.go
+++ b/runner/clients/geth/client.go
@@ -59,22 +59,25 @@ func (g *GethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 
 	g.stdout = cfg.Stdout
 	g.stderr = cfg.Stderr
+	args := make([]string, 0)
 
 	// first init geth
-	args := make([]string, 0)
-	args = append(args, "--datadir", g.options.DataDirPath)
-	args = append(args, "--state.scheme", "hash")
+	if !g.options.SkipInit {
+		args = append(args, "--datadir", g.options.DataDirPath)
+		args = append(args, "--state.scheme", "hash")
 
-	args = append(args, "init", g.options.ChainCfgPath)
+		args = append(args, "init", g.options.ChainCfgPath)
 
-	cmd := exec.CommandContext(ctx, g.options.GethBin, args...)
-	cmd.Stdout = g.stdout
-	cmd.Stderr = g.stderr
+		cmd := exec.CommandContext(ctx, g.options.GethBin, args...)
+		cmd.Stdout = g.stdout
+		cmd.Stderr = g.stderr
 
-	err := cmd.Run()
-	if err != nil {
-		return errors.Wrap(err, "failed to init geth")
+		err := cmd.Run()
+		if err != nil {
+			return errors.Wrap(err, "failed to init geth")
+		}
 	}
+
 
 	args = make([]string, 0)
 	args = append(args, "--datadir", g.options.DataDirPath)
@@ -94,6 +97,7 @@ func (g *GethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 	args = append(args, "--txpool.accountqueue", "1000000")
 	args = append(args, "--maxpeers", "0")
 	args = append(args, "--nodiscover")
+	args = append(args, "--rpc.txfeecap", "20")
 	args = append(args, "--syncmode", "full")
 	args = append(args, "--http.api", "eth,net,web3,miner,debug")
 	args = append(args, "--gcmode", "archive")

--- a/runner/clients/geth/options/options.go
+++ b/runner/clients/geth/options/options.go
@@ -7,4 +7,5 @@ type GethOptions struct {
 	GethHttpPort    int
 	GethAuthRpcPort int
 	GethMetricsPort int
+	SkipInit        bool
 }

--- a/runner/clients/reth/client.go
+++ b/runner/clients/reth/client.go
@@ -69,6 +69,8 @@ func (r *RethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 	args = append(args, "--txpool.pending-max-size", "100")
 	args = append(args, "--txpool.queued-max-size", "100")
 
+	args = append(args, "--db.read-transaction-timeout", "0")
+
 	// delete datadir/txpool-transactions-backup.rlp if it exists
 	txpoolBackupPath := fmt.Sprintf("%s/txpool-transactions-backup.rlp", r.options.DataDirPath)
 	if _, err := os.Stat(txpoolBackupPath); err == nil {
@@ -133,7 +135,7 @@ func (r *RethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 		return errors.Wrap(err, "geth rpc failed to start")
 	}
 
-	l2Node, err := client.NewRPC(ctx, r.logger, fmt.Sprintf("http://127.0.0.1:%d", r.options.RethAuthRpcPort), client.WithGethRPCOptions(rpc.WithHTTPAuth(node.NewJWTAuth(jwtSecret))), client.WithCallTimeout(30*time.Second))
+	l2Node, err := client.NewRPC(ctx, r.logger, fmt.Sprintf("http://127.0.0.1:%d", r.options.RethAuthRpcPort), client.WithGethRPCOptions(rpc.WithHTTPAuth(node.NewJWTAuth(jwtSecret))), client.WithCallTimeout(240*time.Second))
 	if err != nil {
 		return err
 	}

--- a/runner/network/consensus/validator_consensus.go
+++ b/runner/network/consensus/validator_consensus.go
@@ -29,7 +29,6 @@ func NewSyncingConsensusClient(log log.Logger, client *ethclient.Client, authCli
 
 // Propose starts block generation, waits BlockTime, and generates a block.
 func (f *SyncingConsensusClient) propose(ctx context.Context, payload *engine.ExecutableData, blockMetrics *metrics.BlockMetrics) error {
-	f.log.Info("Updating fork choice before validating payload", "payload_index", payload.Number)
 
 	root := crypto.Keccak256Hash([]byte("fake-beacon-block-root"), big.NewInt(1).Bytes())
 


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

All very small changes:

- Increases RPC timeouts
- Uses larger gas limit during setup for quicker testing
- Add `complete` to benchmark results to show in progress tests correctly instead of failed
- Skip geth init for snapshots because it's already initialized
- Remove extra info logs and add logs when node starts up to check block number consistency

# Testing

<!-- How was the code in this PR tested? -->

Tested in conjunction with mainnet tx generator tests on Geth.
