### PR TITLE
feat: allow transfer payload worker to create accounts

### DIFF
--- a/runner/payload/factory.go
+++ b/runner/payload/factory.go
@@ -32,7 +32,7 @@ func NewPayloadWorker(ctx context.Context, log log.Logger, testConfig *benchtype
 			log, sequencerClient.ClientURL(), params, privateKey, amount, config.TxFuzzBinary(), genesis.Config.ChainID)
 	case "transfer-only":
 		worker, err = transferonly.NewTransferPayloadWorker(
-			ctx, log, sequencerClient.ClientURL(), params, privateKey, amount, &genesis)
+			ctx, log, sequencerClient.ClientURL(), params, privateKey, amount, &genesis, definition.Params)
 	case "contract":
 		worker, err = contract.NewContractPayloadWorker(
 			log, sequencerClient.ClientURL(), params, privateKey, amount, &genesis, config, definition.Params)


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

Allow the transfer-only payload worker to create accounts by sending to random addresses instead of to the next address in the wallet.

# Testing

<!-- How was the code in this PR tested? -->

Tested by comparing to the mainnet tx generator with only account creates.
