### PR TITLE
feat: add metric thresholds to benchmark runs

### DIFF
--- a/runner/benchmark/definition.go
+++ b/runner/benchmark/definition.go
@@ -92,8 +92,9 @@ type BenchmarkConfig struct {
 // TestDefinition is the user-facing YAML configuration for specifying a
 // matrix of benchmark runs.
 type TestDefinition struct {
-	Name         string               `yaml:"name"`
-	Snapshot     *SnapshotDefinition  `yaml:"snapshot"`
+	Name     string              `yaml:"name"`
+	Snapshot *SnapshotDefinition `yaml:"snapshot"`
+	Metrics  *ThresholdConfig    `yaml:"metrics"`
 	Description  string               `yaml:"description"`
 	Tags         *map[string]string   `yaml:"tags"`
 	Variables    []Param              `yaml:"variables"`

--- a/runner/benchmark/matrix.go
+++ b/runner/benchmark/matrix.go
@@ -8,11 +8,17 @@ import (
 	"time"
 )
 
+type ThresholdConfig struct {
+	Warning map[string]float64 `yaml:"warning" json:"warning"`
+	Error   map[string]float64 `yaml:"error" json:"error"`
+}
+
 // TestPlan represents a list of test runs to be executed.
 type TestPlan struct {
 	Runs         []TestRun
 	Snapshot     *SnapshotDefinition
 	ProofProgram *ProofProgramOptions
+	Thresholds   *ThresholdConfig
 }
 
 func NewTestPlanFromConfig(c TestDefinition, testFileName string) (*TestPlan, error) {
@@ -36,6 +42,7 @@ func NewTestPlanFromConfig(c TestDefinition, testFileName string) (*TestPlan, er
 		Runs:         testRuns,
 		Snapshot:     c.Snapshot,
 		ProofProgram: proofProgram,
+		Thresholds:   c.Metrics,
 	}, nil
 }
 

--- a/runner/benchmark/result_metadata.go
+++ b/runner/benchmark/result_metadata.go
@@ -34,6 +34,7 @@ type BenchmarkRun struct {
 	TestDescription string                 `json:"testDescription"`
 	TestConfig      map[string]interface{} `json:"testConfig"`
 	Result          *BenchmarkRunResult    `json:"result"`
+	Thresholds      *ThresholdConfig       `json:"thresholds"`
 }
 
 // BenchmarkRuns is the output JSON metadata file schema.
@@ -65,6 +66,7 @@ func BenchmarkMetadataFromTestPlans(testPlans []TestPlan) BenchmarkRuns {
 				TestDescription: params.Description,
 				TestConfig:      params.Params.ToConfig(),
 				OutputDir:       params.OutputDir,
+				Thresholds:      testPlan.Thresholds,
 			})
 		}
 	}


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

Emit metric thresholds based on the config file for each test  run. This will tell the UI what counts as a warning and what counts as an error in testing.

# Testing

<!-- How was the code in this PR tested? -->

Tested end to end with next UI PR.
