### PR TITLE
fix: correct misleading error logs for account chunk initialization

### DIFF
--- a/runner/payload/simulator/worker.go
+++ b/runner/payload/simulator/worker.go
@@ -251,7 +251,7 @@ func (t *simulatorPayloadWorker) testForBlocks(ctx context.Context, simulator *a
 	for i := uint64(0); i < accountChunks; i++ {
 		accountChunkTx, err := simulator.InitializeAddressChunk(t.transactor)
 		if err != nil {
-			return errors.Wrap(err, "failed to initialize storage chunk")
+			return errors.Wrap(err, "failed to initialize account chunk")
 		}
 		t.contractBackend.incrementNonce()
 
@@ -329,7 +329,7 @@ func (t *simulatorPayloadWorker) testForBlocks(ctx context.Context, simulator *a
 	for i := uint64(0); i < accountChunks; i++ {
 		accountChunkTx, err := simulator.InitializeAddressChunk(t.transactor)
 		if err != nil {
-			return errors.Wrap(err, "failed to initialize storage chunk")
+			return errors.Wrap(err, "failed to initialize account chunk")
 		}
 		t.contractBackend.incrementNonce()
 


### PR DESCRIPTION
# Description

In runner/payload/simulator/worker.go, two error branches inside the accountChunks loop call InitializeAddressChunk but logged “failed to initialize storage chunk”. This mislabels the failing operation and misleads debugging/grep. Updated both messages to “failed to initialize account chunk”. 
