### PR TITLE
fix: relative path when on gha

### DIFF
--- a/report/src/services/dataService.ts
+++ b/report/src/services/dataService.ts
@@ -11,11 +11,11 @@ export class DataService {
   private baseUrl: string;
 
   constructor(baseUrl: string) {
-    this.baseUrl = baseUrl.replace(/\/$/, ""); // Remove trailing slash
+    this.baseUrl = baseUrl.replace(/\/$/, "") + "/"; // Ensure trailing slash
   }
 
   async getMetadata(): Promise<BenchmarkRuns> {
-    const response = await fetch(`${this.baseUrl}/output/metadata.json`);
+    const response = await fetch(`${this.baseUrl}output/metadata.json`);
 
     if (!response.ok) {
       throw new Error(
@@ -27,7 +27,7 @@ export class DataService {
   }
 
   async getMetrics(outputDir: string, nodeType: string): Promise<MetricData[]> {
-    const metricsPath = `${this.baseUrl}/output/${outputDir}/metrics-${nodeType}.json`;
+    const metricsPath = `${this.baseUrl}output/${outputDir}/metrics-${nodeType}.json`;
     const response = await fetch(metricsPath);
 
     if (!response.ok) {
@@ -72,7 +72,7 @@ export function getDataSourceConfig(): DataServiceConfig {
   const dataSource = getEnvVar("DATA_SOURCE") || "static";
 
   if (dataSource === "api" && apiBaseUrl) {
-    // API mode: use the configured API base URL
+    // API mode: use the configured API base URL (ensure trailing slash)
     return { baseUrl: apiBaseUrl };
   } else {
     // Static mode: use current origin (empty string means relative to current domain)


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

Fixes fetching metadata and test runs on GHA. Previously, we used a relative path, so requesting `output/metadata.json` would resolve to `https://base.github.io/benchmark/output/metadata.json` when requested from `https://base.github.io/benchmark`.

The previous change added a leading `/` to the beginning of the path, so it was not resolving the relative path correctly. Now, we ensure the base url has a trailing `/` and remove the leading `/` from request URLs so the static site is portable to any path.

# Testing

<!-- How was the code in this PR tested? -->
