### PR TITLE
feat: allow specifying different node args for each run

### DIFF
--- a/runner/benchmark/benchmark.go
+++ b/runner/benchmark/benchmark.go
@@ -80,6 +80,24 @@ func NewParamsFromValues(assignments map[string]interface{}) (*types.RunParams, 
 			} else {
 				return nil, fmt.Errorf("invalid num blocks %s", v)
 			}
+		case "node_args":
+			// either a list of strings or a string (separated by spaces)
+			if vStr, ok := v.(string); ok {
+				params.NodeArgs = strings.Split(vStr, " ")
+			} else if vArr, ok := v.([]interface{}); ok {
+				// convert []interface{} to []string
+				nodeArgs := make([]string, len(vArr))
+				for i, arg := range vArr {
+					arg, ok := arg.(string)
+					if !ok {
+						return nil, fmt.Errorf("invalid non-string node arg %v", arg)
+					}
+					nodeArgs[i] = arg
+				}
+				params.NodeArgs = nodeArgs
+			} else {
+				return nil, fmt.Errorf("invalid node args %v", v)
+			}
 		}
 	}
 

--- a/runner/clients/reth/client.go
+++ b/runner/clients/reth/client.go
@@ -92,8 +92,6 @@ func (r *RethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 	args = append(args, "--engine.state-provider-metrics")
 	args = append(args, "-vvv")
 
-	args = append(args, cfg.Args...)
-
 	// increase mempool size
 	args = append(args, "--txpool.pending-max-count", "100000000")
 	args = append(args, "--txpool.queued-max-count", "100000000")
@@ -101,6 +99,7 @@ func (r *RethClient) Run(ctx context.Context, cfg *types.RuntimeConfig) error {
 	args = append(args, "--txpool.queued-max-size", "100")
 
 	args = append(args, "--db.read-transaction-timeout", "0")
+	args = append(args, cfg.Args...)
 
 	// delete datadir/txpool-transactions-backup.rlp if it exists
 	txpoolBackupPath := fmt.Sprintf("%s/txpool-transactions-backup.rlp", r.options.DataDirPath)

--- a/runner/config/client.go
+++ b/runner/config/client.go
@@ -64,4 +64,7 @@ func ReadClientOptions(ctx *cli.Context) ClientOptions {
 }
 
 // CommonOptions are common client configuration options.
-type CommonOptions struct{}
+type CommonOptions struct {
+	// NodeArgs are the arguments to be passed to the node binary.
+	NodeArgs []string
+}

--- a/runner/config/doc.go
+++ b/runner/config/doc.go
@@ -1,0 +1,6 @@
+/*
+config is responsible for reading and validating runtime configuration for the benchmark runner.
+
+These config options are not stored in the config file, but are set by the CLI flags.
+*/
+package config

--- a/runner/network/network_benchmark.go
+++ b/runner/network/network_benchmark.go
@@ -198,6 +198,7 @@ func setupNode(ctx context.Context, l log.Logger, params benchtypes.RunParams, o
 	runtimeConfig := &types.RuntimeConfig{
 		Stdout: stdoutLogger,
 		Stderr: stderrLogger,
+		Args:   options.NodeArgs,
 	}
 
 	if err := client.Run(ctx, runtimeConfig); err != nil {

--- a/runner/network/types/types.go
+++ b/runner/network/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"crypto/ecdsa"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/base/base-bench/runner/config"
@@ -52,16 +53,38 @@ func (c *TestConfig) BatcherAddr() common.Address {
 
 // Params is the parameters for a single benchmark run.
 type RunParams struct {
-	NodeType       string
-	GasLimit       uint64
-	PayloadID      string
+	// NodeType is the type of node that's being benchmarked. Examples: geth, reth, nethermined, etc.
+	NodeType string
+
+	// GasLimit is the gas limit for the benchmark run which is the maximum gas that the sequencer will include per block.
+	GasLimit uint64
+
+	// PayloadID is a reference to a transaction payload that will be sent to the sequencer.
+	PayloadID string
+
+	// BenchmarkRunID is a unique identifier for the benchmark run.
 	BenchmarkRunID string
-	Name           string
-	Description    string
-	BlockTime      time.Duration
-	Env            map[string]string
-	NumBlocks      int
-	Tags           map[string]string
+
+	// Name is the name of the benchmark run in the config file.
+	Name string
+
+	// Description is the description of the benchmark run in the config file.
+	Description string
+
+	// BlockTime is the time between blocks in the benchmark run.
+	BlockTime time.Duration
+
+	// Env is the environment variables for the benchmark run.
+	Env map[string]string
+
+	// NumBlocks is the number of blocks to run in the benchmark run.
+	NumBlocks int
+
+	// Tags are the tags for the benchmark run.
+	Tags map[string]string
+
+	// NodeArgs are the arguments to be passed to the node binary.
+	NodeArgs []string
 }
 
 func (p RunParams) ToConfig() map[string]interface{} {
@@ -71,6 +94,7 @@ func (p RunParams) ToConfig() map[string]interface{} {
 		"TransactionPayload":    p.PayloadID,
 		"BenchmarkRun":          p.BenchmarkRunID,
 		"BlockTimeMilliseconds": p.BlockTime.Milliseconds(),
+		"NodeArgs":              strings.Join(p.NodeArgs, " "),
 	}
 
 	for k, v := range p.Tags {
@@ -82,6 +106,7 @@ func (p RunParams) ToConfig() map[string]interface{} {
 
 // ClientOptions applies any client customization options to the given client options.
 func (p RunParams) ClientOptions(prevClientOptions config.ClientOptions) config.ClientOptions {
+	prevClientOptions.NodeArgs = p.NodeArgs
 	return prevClientOptions
 }
 


### PR DESCRIPTION
# Description

<!-- What change is this PR making? -->

Allow specifying node args to add for each run.

Example config:

```yaml
name: Reth SAFE_NO_SYNC Comparison Example
description: |
  Compares performance of Reth SAFE_NO_SYNC vs. DURABLE options with a write-heavy workload. This was run on ZFS for easy iteration, so the results are not directly comparable to other filesystems.

payloads:
  - name: Storage Create
    id: storage-create
    type: simulator
    storage_created: 1
      
benchmarks:
  - variables:
      - type: payload
        values:
          - storage-create
      - type: node_type
        values:
          - reth
      - type: num_blocks
        value: 100
      - type: node_args
        values:
          - ["--db.sync-mode", "safe_no_sync"]
          - ["--db.sync-mode", "durable"]
      - type: gas_limit
        value: 75000000
```

# Testing

<!-- How was the code in this PR tested? -->

Tested with Reth using `--db.sync-mode safe-no-sync`
