### PR TITLE
feat: allow specifying num callers for simulator

### DIFF
--- a/runner/payload/factory.go
+++ b/runner/payload/factory.go
@@ -2,7 +2,7 @@ package payload
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	clienttypes "github.com/base/base-bench/runner/clients/types"
 	benchtypes "github.com/base/base-bench/runner/network/types"
@@ -41,7 +41,7 @@ func NewPayloadWorker(ctx context.Context, log log.Logger, testConfig *benchtype
 		worker, err = simulator.NewSimulatorPayloadWorker(
 			ctx, log, sequencerClient.ClientURL(), params, privateKey, amount, &genesis, definition.Params)
 	default:
-		return nil, errors.New("invalid payload type")
+		return nil, fmt.Errorf("invalid payload type: %s", definition.Type)
 	}
 
 	return worker, err

--- a/runner/payload/simulator/simulatorstats/types.go
+++ b/runner/payload/simulator/simulatorstats/types.go
@@ -131,6 +131,9 @@ type StatsConfig struct {
 	Opcodes            *OpcodeStats `yaml:"opcodes"`
 	Precompiles        *OpcodeStats `yaml:"precompiles"`
 	AvgGasUsed         *float64     `yaml:"avg_gas_used"`
+	// NumCallers is the number of caller accounts to distribute transactions across.
+	// Defaults to 1 if not specified.
+	NumCallers *int `yaml:"num_callers"`
 }
 
 func (s *StatsConfig) ToStats() *Stats {


### PR DESCRIPTION
This allows testing things like Block-STM where the number of callers affects performance. If we use a single caller, every transaction conflicts with the next transaction on the balance/nonce of the caller.

# Description

<!-- What change is this PR making? -->

# Testing

<!-- How was the code in this PR tested? -->
