### PR TITLE
feat: handle emitted Flashblock websocket messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,14 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/ethereum-optimism/optimism v1.16.2
 	github.com/ethereum/go-ethereum v1.16.5
+	github.com/gorilla/websocket v1.5.3
 	github.com/holiman/uint256 v1.3.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.4
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
+	golang.org/x/sync v0.18.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -77,7 +79,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/graph-gophers/graphql-go v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.15 // indirect
@@ -153,7 +154,6 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20251125195548-87e1e737ad39 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/runner/clients/geth/client.go
+++ b/runner/clients/geth/client.go
@@ -270,3 +270,8 @@ func (g *GethClient) SetHead(ctx context.Context, blockNumber uint64) error {
 	g.logger.Info("Successfully reset blockchain head", "blockNumber", blockNumber, "blockHex", blockHex)
 	return nil
 }
+
+// FlashblocksClient returns nil as geth does not support flashblocks.
+func (g *GethClient) FlashblocksClient() types.FlashblocksClient {
+	return nil
+}

--- a/runner/clients/rbuilder/flashblocks_client.go
+++ b/runner/clients/rbuilder/flashblocks_client.go
@@ -1,0 +1,213 @@
+package rbuilder
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/base/base-bench/runner/clients/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/gorilla/websocket"
+)
+
+// flashblocksClient implements the FlashblocksClient interface for collecting
+// flashblock payloads from rbuilder via websocket and broadcasting them to listeners.
+type flashblocksClient struct {
+	log       log.Logger
+	port      uint64
+	conn      *websocket.Conn
+	listeners []types.FlashblockListener
+	mu        sync.RWMutex
+	stopChan  chan struct{}
+	stopOnce  sync.Once
+}
+
+// NewFlashblocksClient creates a new flashblocks websocket client.
+func NewFlashblocksClient(log log.Logger, port uint64) types.FlashblocksClient {
+	return &flashblocksClient{
+		log:       log,
+		port:      port,
+		listeners: make([]types.FlashblockListener, 0),
+		stopChan:  make(chan struct{}),
+	}
+}
+
+// Start begins collecting flashblocks from the websocket connection.
+// This method connects to the websocket in a goroutine to avoid blocking.
+func (f *flashblocksClient) Start(ctx context.Context) error {
+	url := fmt.Sprintf("ws://localhost:%d", f.port)
+	f.log.Info("Connecting to flashblocks websocket", "url", url)
+
+	// Use a separate context with timeout for the connection attempt
+	connectCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	dialer := websocket.DefaultDialer
+	conn, _, err := dialer.DialContext(connectCtx, url, nil)
+	if err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	f.conn = conn
+	f.mu.Unlock()
+
+	f.log.Info("Connected to flashblocks websocket", "url", url)
+
+	// Read messages in this goroutine
+	go f.readMessages(ctx)
+
+	return nil
+}
+
+// readMessages reads flashblock messages from the websocket in a blocking loop.
+// It exits on any error or when the context is cancelled.
+func (f *flashblocksClient) readMessages(ctx context.Context) {
+	defer func() {
+		f.mu.Lock()
+		if f.conn != nil {
+			err := f.conn.Close()
+			if err != nil {
+				f.log.Warn("Error closing flashblocks websocket connection", "err", err)
+			}
+			f.conn = nil
+		}
+		f.mu.Unlock()
+	}()
+
+	// Channel to signal when a message is received or error occurs
+	type readResult struct {
+		message []byte
+		err     error
+	}
+	readChan := make(chan readResult, 1)
+
+	// Start a goroutine to read from the websocket
+	go func() {
+		for {
+			_, message, err := f.conn.ReadMessage()
+			readChan <- readResult{message: message, err: err}
+			if err != nil {
+				// Exit on any error to avoid panic on repeated reads
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			f.log.Debug("Context cancelled, stopping flashblocks client")
+			return
+		case <-f.stopChan:
+			f.log.Debug("Stop signal received, stopping flashblocks client")
+			return
+		case result := <-readChan:
+			if result.err != nil {
+				// Check if this is a normal closure
+				if websocket.IsCloseError(result.err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					f.log.Debug("Flashblocks websocket closed normally")
+				}
+				return
+			}
+
+			// Deserialize flashblock payload
+			var flashblock types.FlashblocksPayloadV1
+			if err := json.Unmarshal(result.message, &flashblock); err != nil {
+				f.log.Warn("Failed to deserialize flashblock payload", "err", err)
+				continue
+			}
+
+			// Log flashblock details at DEBUG level
+			txCount := len(flashblock.Diff.Transactions)
+			f.log.Debug("Received flashblock",
+				"payload_id", fmt.Sprintf("%x", flashblock.PayloadID),
+				"index", flashblock.Index,
+				"tx_count", txCount,
+				"gas_used", flashblock.Diff.GasUsed,
+				"block_hash", flashblock.Diff.BlockHash.Hex(),
+			)
+
+			// Broadcast to all listeners
+			f.broadcastFlashblock(flashblock)
+		}
+	}
+}
+
+// Stop stops collection and closes the websocket connection.
+// This method is idempotent and can be called multiple times safely.
+func (f *flashblocksClient) Stop() error {
+	// Use sync.Once to ensure cleanup only happens once
+	var stopErr error
+	f.stopOnce.Do(func() {
+		f.log.Info("Stopping flashblocks client")
+
+		// Signal the read goroutine to stop
+		close(f.stopChan)
+
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		if f.conn != nil {
+			// Send close message
+			err := f.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			if err != nil {
+				f.log.Warn("Error sending close message to flashblocks websocket", "err", err)
+			}
+
+			// Close the connection
+			err = f.conn.Close()
+			if err != nil {
+				f.log.Warn("Error closing flashblocks websocket connection", "err", err)
+				stopErr = err
+			}
+			f.conn = nil
+		}
+
+		f.log.Info("Flashblocks client stopped")
+	})
+
+	return stopErr
+}
+
+// AddListener registers a listener to receive flashblock payloads.
+func (f *flashblocksClient) AddListener(listener types.FlashblockListener) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listeners = append(f.listeners, listener)
+	f.log.Debug("Added flashblock listener", "total_listeners", len(f.listeners))
+}
+
+// RemoveListener unregisters a listener.
+func (f *flashblocksClient) RemoveListener(listener types.FlashblockListener) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for i, l := range f.listeners {
+		if l == listener {
+			f.listeners = append(f.listeners[:i], f.listeners[i+1:]...)
+			f.log.Debug("Removed flashblock listener", "total_listeners", len(f.listeners))
+			return
+		}
+	}
+}
+
+// broadcastFlashblock sends the flashblock to all registered listeners.
+func (f *flashblocksClient) broadcastFlashblock(flashblock types.FlashblocksPayloadV1) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	for _, listener := range f.listeners {
+		// Call each listener (synchronously for now)
+		listener.OnFlashblock(flashblock)
+	}
+}
+
+// IsConnected returns true if the websocket connection is active.
+func (f *flashblocksClient) IsConnected() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.conn != nil
+}

--- a/runner/clients/reth/client.go
+++ b/runner/clients/reth/client.go
@@ -278,3 +278,8 @@ func (r *RethClient) SetHead(ctx context.Context, blockNumber uint64) error {
 	r.logger.Info("Successfully reset blockchain head", "blockNumber", blockNumber, "blockHex", blockHex)
 	return nil
 }
+
+// FlashblocksClient returns nil as reth does not support flashblocks.
+func (r *RethClient) FlashblocksClient() types.FlashblocksClient {
+	return nil
+}

--- a/runner/clients/types/flashblock.go
+++ b/runner/clients/types/flashblock.go
@@ -1,0 +1,102 @@
+package types
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// ExecutionPayloadFlashblockDeltaV1 represents the modified portions of an execution payload
+// within a flashblock. This structure contains only the fields that can be updated during
+// block construction, such as state root, receipts, logs, and new transactions.
+type ExecutionPayloadFlashblockDeltaV1 struct {
+	// StateRoot is the state root of the block
+	StateRoot common.Hash `json:"state_root"`
+	// ReceiptsRoot is the receipts root of the block
+	ReceiptsRoot common.Hash `json:"receipts_root"`
+	// LogsBloom is the logs bloom of the block
+	LogsBloom types.Bloom `json:"logs_bloom"`
+	// GasUsed is the gas used of the block
+	GasUsed hexutil.Uint64 `json:"gas_used"`
+	// BlockHash is the block hash of the block
+	BlockHash common.Hash `json:"block_hash"`
+	// Transactions are the transactions of the block
+	Transactions []hexutil.Bytes `json:"transactions"`
+	// Withdrawals are the withdrawals enabled with V2
+	Withdrawals []Withdrawal `json:"withdrawals"`
+	// WithdrawalsRoot is the withdrawals root of the block
+	WithdrawalsRoot common.Hash `json:"withdrawals_root"`
+	// BlobGasUsed is the blob gas used
+	BlobGasUsed *hexutil.Uint64 `json:"blob_gas_used,omitempty"`
+}
+
+// Withdrawal represents a validator withdrawal
+type Withdrawal struct {
+	Index     hexutil.Uint64 `json:"index"`
+	Validator hexutil.Uint64 `json:"validator"`
+	Address   common.Address `json:"address"`
+	Amount    hexutil.Uint64 `json:"amount"`
+}
+
+// ExecutionPayloadBaseV1 represents the base configuration of an execution payload that
+// remains constant throughout block construction. This includes fundamental block properties
+// like parent hash, block number, and other header fields that are determined at block
+// creation and cannot be modified.
+type ExecutionPayloadBaseV1 struct {
+	// ParentBeaconBlockRoot is the Ecotone parent beacon block root
+	ParentBeaconBlockRoot common.Hash `json:"parent_beacon_block_root"`
+	// ParentHash is the parent hash of the block
+	ParentHash common.Hash `json:"parent_hash"`
+	// FeeRecipient is the fee recipient of the block
+	FeeRecipient common.Address `json:"fee_recipient"`
+	// PrevRandao is the previous randao of the block
+	PrevRandao common.Hash `json:"prev_randao"`
+	// BlockNumber is the block number
+	BlockNumber hexutil.Uint64 `json:"block_number"`
+	// GasLimit is the gas limit of the block
+	GasLimit hexutil.Uint64 `json:"gas_limit"`
+	// Timestamp is the timestamp of the block
+	Timestamp hexutil.Uint64 `json:"timestamp"`
+	// ExtraData is the extra data of the block
+	ExtraData hexutil.Bytes `json:"extra_data"`
+	// BaseFeePerGas is the base fee per gas of the block
+	BaseFeePerGas *hexutil.Big `json:"base_fee_per_gas"`
+}
+
+// PayloadID is a unique identifier for a payload
+type PayloadID [8]byte
+
+// MarshalJSON implements json.Marshaler for PayloadID
+func (p PayloadID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hexutil.Bytes(p[:]))
+}
+
+// UnmarshalJSON implements json.Unmarshaler for PayloadID
+func (p *PayloadID) UnmarshalJSON(data []byte) error {
+	var b hexutil.Bytes
+	if err := json.Unmarshal(data, &b); err != nil {
+		return err
+	}
+	if len(b) != 8 {
+		return json.Unmarshal(data, &b)
+	}
+	copy(p[:], b)
+	return nil
+}
+
+// FlashblocksPayloadV1 represents a flashblock payload containing the base execution
+// payload configuration and the delta/diff containing modified portions.
+type FlashblocksPayloadV1 struct {
+	// PayloadID is the payload id of the flashblock
+	PayloadID PayloadID `json:"payload_id"`
+	// Index is the index of the flashblock in the block
+	Index uint64 `json:"index"`
+	// Base is the base execution payload configuration (optional, only present in first flashblock)
+	Base *ExecutionPayloadBaseV1 `json:"base,omitempty"`
+	// Diff is the delta/diff containing modified portions of the execution payload
+	Diff ExecutionPayloadFlashblockDeltaV1 `json:"diff"`
+	// Metadata is additional metadata associated with the flashblock
+	Metadata json.RawMessage `json:"metadata"`
+}

--- a/runner/clients/types/flashblocks_client.go
+++ b/runner/clients/types/flashblocks_client.go
@@ -1,0 +1,29 @@
+package types
+
+import "context"
+
+// FlashblockListener receives flashblock payloads as they are received from the websocket.
+type FlashblockListener interface {
+	// OnFlashblock is called when a new flashblock payload is received
+	OnFlashblock(flashblock FlashblocksPayloadV1)
+}
+
+// FlashblocksClient is an interface for collecting flashblock payloads from a websocket connection.
+// Only clients that support flashblocks (e.g., rbuilder) will provide a non-nil implementation.
+// It uses a broadcast pattern where listeners can subscribe to receive flashblock updates.
+type FlashblocksClient interface {
+	// Start begins collecting flashblocks from the websocket connection
+	Start(ctx context.Context) error
+
+	// Stop stops collection and closes the websocket connection
+	Stop() error
+
+	// AddListener registers a listener to receive flashblock payloads
+	AddListener(listener FlashblockListener)
+
+	// RemoveListener unregisters a listener
+	RemoveListener(listener FlashblockListener)
+
+	// IsConnected returns true if the websocket connection is active
+	IsConnected() bool
+}

--- a/runner/clients/types/types.go
+++ b/runner/clients/types/types.go
@@ -27,4 +27,5 @@ type ExecutionClient interface {
 	MetricsCollector() metrics.Collector
 	GetVersion(ctx context.Context) (string, error)
 	SetHead(ctx context.Context, blockNumber uint64) error
+	FlashblocksClient() FlashblocksClient // returns nil for clients that don't support flashblocks
 }

--- a/runner/network/network_benchmark.go
+++ b/runner/network/network_benchmark.go
@@ -108,14 +108,14 @@ func (nb *NetworkBenchmark) benchmarkSequencer(ctx context.Context, l1Chain *l1C
 	}()
 
 	benchmark := newSequencerBenchmark(nb.log, *nb.testConfig, sequencerClient, l1Chain, nb.transactionPayload)
-	executionData, lastBlock, err := benchmark.Run(ctx, metricsCollector)
+	payloadResult, lastBlock, err := benchmark.Run(ctx, metricsCollector)
 
 	if err != nil {
 		sequencerClient.Stop()
 		return nil, 0, nil, fmt.Errorf("failed to run sequencer benchmark: %w", err)
 	}
 
-	return executionData, lastBlock, sequencerClient, nil
+	return payloadResult.ExecutablePayloads, lastBlock, sequencerClient, nil
 }
 
 func (nb *NetworkBenchmark) benchmarkValidator(ctx context.Context, payloads []engine.ExecutableData, lastSetupBlock uint64, l1Chain *l1Chain, sequencerClient types.ExecutionClient) error {

--- a/runner/network/types/payload_result.go
+++ b/runner/network/types/payload_result.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	clientTypes "github.com/base/base-bench/runner/clients/types"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+)
+
+// PayloadResult contains the results from a sequencer benchmark run, including
+// both the executable payloads and any flashblock payloads that were collected.
+type PayloadResult struct {
+	// ExecutablePayloads are the execution payloads generated during the benchmark
+	ExecutablePayloads []engine.ExecutableData
+
+	// Flashblocks are the flashblock payloads collected during the benchmark (if available)
+	Flashblocks []clientTypes.FlashblocksPayloadV1
+}
+
+// HasFlashblocks returns true if flashblock payloads were collected.
+func (p *PayloadResult) HasFlashblocks() bool {
+	return len(p.Flashblocks) > 0
+}


### PR DESCRIPTION
This is the first step to replaying Flashblock messages from the block builder and testing flashblock sync performance.

# Description

<!-- What change is this PR making? -->

- Adds flashblock client to receive flashblocks from the builder
- Adds flashblocks to payload result instead of just full block payloads

# Testing

<!-- How was the code in this PR tested? -->

Tested in CI in next PR (see flashblock messages in log).