### PR TITLE
feat: allow parallel tx sending threads to be configurable

### DIFF
--- a/benchmark/flags/flags.go
+++ b/benchmark/flags/flags.go
@@ -25,6 +25,7 @@ const (
 	MachineProviderFlagName = "machine-provider"
 	MachineRegionFlagName   = "machine-region"
 	FileSystemFlagName      = "file-system"
+	ParallelTxBatchesFlagName = "parallel-tx-batches"
 )
 
 // TxFuzz defaults
@@ -98,6 +99,13 @@ var (
 		Value:   "ext4",
 		EnvVars: prefixEnvVars("FILE_SYSTEM"),
 	}
+
+	ParallelTxBatchesFlag = &cli.IntFlag{
+		Name:    ParallelTxBatchesFlagName,
+		Usage:   "Number of parallel batches for sending transactions",
+		Value:   4,
+		EnvVars: prefixEnvVars("PARALLEL_TX_BATCHES"),
+	}
 )
 
 // Flags contains the list of configuration options available to the binary.
@@ -114,6 +122,7 @@ var RunFlags = []cli.Flag{
 	MachineProviderFlag,
 	MachineRegionFlag,
 	FileSystemFlag,
+	ParallelTxBatchesFlag,
 }
 
 func init() {

--- a/runner/config/config.go
+++ b/runner/config/config.go
@@ -26,6 +26,7 @@ type Config interface {
 	MachineProvider() string
 	MachineRegion() string
 	FileSystem() string
+	ParallelTxBatches() int
 }
 
 type config struct {
@@ -41,6 +42,7 @@ type config struct {
 	machineProvider string
 	machineRegion   string
 	fileSystem      string
+	parallelTxBatches int
 }
 
 func NewConfig(ctx *cli.Context) Config {
@@ -56,6 +58,7 @@ func NewConfig(ctx *cli.Context) Config {
 		machineProvider: ctx.String(appFlags.MachineProviderFlagName),
 		machineRegion:   ctx.String(appFlags.MachineRegionFlagName),
 		fileSystem:      ctx.String(appFlags.FileSystemFlagName),
+		parallelTxBatches: ctx.Int(appFlags.ParallelTxBatchesFlagName),
 		clientOptions:   ReadClientOptions(ctx),
 	}
 }
@@ -127,4 +130,8 @@ func (c *config) MachineRegion() string {
 
 func (c *config) FileSystem() string {
 	return c.fileSystem
+}
+
+func (c *config) ParallelTxBatches() int {
+	return c.parallelTxBatches
 }

--- a/runner/network/consensus/client.go
+++ b/runner/network/consensus/client.go
@@ -21,6 +21,8 @@ type ConsensusClientOptions struct {
 	GasLimit uint64
 	// GasLimitSetup is the gas limit for the setup payload
 	GasLimitSetup uint64
+	// ParallelTxBatches is the number of parallel batches for sending transactions
+	ParallelTxBatches int
 }
 
 // BaseConsensusClient contains common functionality shared between different consensus client implementations.

--- a/runner/network/consensus/sequencer_consensus.go
+++ b/runner/network/consensus/sequencer_consensus.go
@@ -215,8 +215,11 @@ func (f *SequencerConsensusClient) Propose(ctx context.Context, blockMetrics *me
 	sendCallsPerBatch := 100
 	batches := (len(sendTxs) + sendCallsPerBatch - 1) / sendCallsPerBatch
 
-	// Process batches in parallel, 4 at a time
-	parallelBatches := 4
+	// Process batches in parallel
+	parallelBatches := f.options.ParallelTxBatches
+	if parallelBatches <= 0 {
+		parallelBatches = 4 // default
+	}
 	for i := 0; i < batches; i += parallelBatches {
 		g, gCtx := errgroup.WithContext(ctx)
 

--- a/runner/network/sequencer_benchmark.go
+++ b/runner/network/sequencer_benchmark.go
@@ -207,6 +207,7 @@ func (nb *sequencerBenchmark) Run(ctx context.Context, metricsCollector metrics.
 			BlockTime:     params.BlockTime,
 			GasLimit:      params.GasLimit,
 			GasLimitSetup: 1e9, // 1G gas
+			ParallelTxBatches: nb.config.Config.ParallelTxBatches(),
 		}, headBlockHash, headBlockNumber, l1Chain, nb.config.BatcherAddr())
 
 		payloads := make([]engine.ExecutableData, 0)


### PR DESCRIPTION
Adds a new CLI flag `--parallel-tx-batches` to configure the number of parallel batches for sending transactions.

Default value is 4 (preserving existing behavior).

Closes #144