### PR TITLE
fix: keep FCU timestamps at or ahead of wall clock

### DIFF
--- a/runner/network/consensus/sequencer_consensus.go
+++ b/runner/network/consensus/sequencer_consensus.go
@@ -121,11 +121,12 @@ func (f *SequencerConsensusClient) generatePayloadAttributes(sequencerTxs [][]by
 	var b8 eth.Bytes8
 	copy(b8[:], eip1559.EncodeHolocene1559Params(50, 1))
 
+	// Always keep timestamps at or ahead of wall clock so the builder
+	// never sees "FCU arrived too late" and produces empty blocks.
+	now := uint64(time.Now().Unix())
 	lastTimestamp := f.lastTimestamp
-
-	// if the last timestamp is more than 2 seconds in the past, set it to the current time
-	if int64(lastTimestamp)-time.Now().Unix() < -2 {
-		lastTimestamp = uint64(time.Now().Unix())
+	if now > lastTimestamp {
+		lastTimestamp = now
 	}
 
 	timestamp := lastTimestamp + 1


### PR DESCRIPTION
## Summary
- Replaces the 2-second threshold catchup with `max(now, lastTimestamp)` so FCU timestamps never fall behind wall clock
- Fixes `basic-benchmarks` CI flake where the builder sees "FCU arrived too late" on every block, produces empty blocks (0 flashblocks), and the `transferonly` worker times out waiting for a receipt

## Root Cause
Each block cycle (FCU → build → getPayload → newPayload) takes slightly >1s of real time on slow CI runners. The timestamp increments by exactly 1s per block (`lastTimestamp + 1`), so it gradually drifts behind wall clock. The builder's `calculate_flashblocks` subtracts a leeway from the target timestamp, sees no remaining time, and builds 0 flashblocks — producing blocks with only the deposit tx and no pool transactions.

The old 2-second guard never triggered because the per-block drift is <2s, but it accumulates over many blocks.