### PR TITLE
fix: use base/base main branch for base-reth-node builds

### DIFF
--- a/.github/workflows/_build-binaries.yaml
+++ b/.github/workflows/_build-binaries.yaml
@@ -19,7 +19,7 @@ on:
         description: "Base Reth Node version to build"
         required: false
         type: string
-        default: "1e4a8a7"
+        default: "main"
 
 # Set minimal permissions for all jobs by default
 permissions:

--- a/clients/build-base-reth-node.sh
+++ b/clients/build-base-reth-node.sh
@@ -40,8 +40,7 @@ fi
 
 # Checkout specified version/commit
 echo "Checking out version: $BASE_RETH_NODE_VERSION"
-git fetch origin "$BASE_RETH_NODE_VERSION" || true
-git checkout -f "$BASE_RETH_NODE_VERSION" || git checkout -f "origin/$BASE_RETH_NODE_VERSION"
+git checkout -f "$BASE_RETH_NODE_VERSION"
 
 # Build the binaries using cargo
 echo "Building base-reth-node, base-builder, and base-load-test with cargo..."

--- a/clients/versions.env
+++ b/clients/versions.env
@@ -12,7 +12,7 @@ GETH_VERSION="v1.101604.0"
 
 # Base Reth Node Configuration
 BASE_RETH_NODE_REPO="https://github.com/base/base"
-BASE_RETH_NODE_VERSION="1e4a8a7"
+BASE_RETH_NODE_VERSION="main"
 
 # Build Configuration
 # BUILD_DIR="./build"


### PR DESCRIPTION
## Summary

- Reverts `base_reth_node_version` from short commit SHA (`1e4a8a7`) back to `main` in both `versions.env` and `_build-binaries.yaml`
- Simplifies checkout logic in `build-base-reth-node.sh` to match `build-reth.sh`

## Root Cause

PR #175 changed `BASE_RETH_NODE_VERSION` from `main` to the short SHA `1e4a8a7`. GitHub does not allow fetching arbitrary commit SHAs as refs, so `git fetch origin 1e4a8a7` fails during CI with:

```
fatal: couldn't find remote ref 1e4a8a7
```

The commit exists in `base/base`, but Git's protocol doesn't support fetching by raw SHA from GitHub remotes.

## Changes

1. **`clients/versions.env`** — `BASE_RETH_NODE_VERSION` back to `main`
2. **`.github/workflows/_build-binaries.yaml`** — default input back to `main`
3. **`clients/build-base-reth-node.sh`** — removed `git fetch origin "$VERSION" || true` + fallback checkout; now uses a single `git checkout -f "$VERSION"` matching the pattern in `build-reth.sh`