### PR TITLE
fix(simulator): remove double-application of scaleFactor in targetCalls

### DIFF
--- a/runner/payload/simulator/worker.go
+++ b/runner/payload/simulator/worker.go
@@ -595,7 +595,7 @@ func (t *simulatorPayloadWorker) sendTxs(ctx context.Context, pendingTxs int) (i
 
 	sendTxsStartTime := time.Now()
 
-	targetCalls := uint64(math.Ceil(float64(t.numCallsPerBlock) * t.scaleFactor))
+	targetCalls := t.numCallsPerBlock
 	var callsToSend uint64
 	if uint64(pendingTxs) >= targetCalls {
 		callsToSend = 0


### PR DESCRIPTION
## Root cause

`scaleFactor` is applied **per-tx** inside `sendTxs` to scale up the operations each transaction performs:

```go
// line 608 — scaleFactor applied inside each tx's operation count
expected := t.payloadParams.Mul(float64(t.numCalls+1) * t.scaleFactor)
blockCounts := expected.Sub(actual).Round()
```

So each tx already does `scaleFactor × payloadParams` operations. With `avg_gas_used=35M` and `GasLimit=200M`, `scaleFactor≈5.71`, so each tx does ~280 storage reads instead of the base 49.

`targetCalls` was then computed as:

```go
targetCalls := uint64(math.Ceil(float64(t.numCallsPerBlock) * t.scaleFactor))
// = ceil(100 * 5.71) = 572
```

This multiplied `scaleFactor` in **a second time** at the tx-count level. The builder only absorbs ~100 txs/block (one `numCallsPerBlock`'s worth of gas). After 2 blocks `pendingTxs` grew past 572 and `callsToSend=0` forever — producing empty (deposit-only) blocks for the rest of the run.

Only affected workloads with both `avg_gas_used` and a numeric `calls_per_block` set, which is only `base-mainnet-simulation` in the public configs. All other payloads leave `scaleFactor=1.0` so the double-application is a no-op.

Observed: **7,000+ consecutive empty blocks** in a 900-block `base-mainnet-simulation` run.

## Fix

```go
// Before
targetCalls := uint64(math.Ceil(float64(t.numCallsPerBlock) * t.scaleFactor))

// After
targetCalls := t.numCallsPerBlock
```

`scaleFactor` belongs only in the per-tx operation calculation (line 608). `numCallsPerBlock` is already the correct tx count — it is derived from gas estimation that already accounts for each tx doing `scaleFactor` worth of operations.