### PR TITLE
feat: add simulator load-test payload + fix proxy batch RPC + wire flashblocks WS

### DIFF
--- a/configs/examples/load-test-simulator.yml
+++ b/configs/examples/load-test-simulator.yml
@@ -1,0 +1,25 @@
+name: Simulator load-test throughput test
+description: Test builder throughput using base-load-tester with the simulator payload. The Simulator contract is deployed automatically via CREATE before the test starts if not already present.
+payloads:
+  - name: Load Test Simulator
+    type: load-test
+    id: load-test-simulator
+    sender_count: 5
+    transactions:
+      - weight: 100
+        type: simulator
+        create_storage: 10
+        create_accounts: 5
+
+benchmarks:
+  - variables:
+      - type: payload
+        value: load-test-simulator
+      - type: node_type
+        value: builder
+      - type: validator_node_type
+        value: base-reth-node
+      - type: num_blocks
+        value: 20
+      - type: gas_limit
+        value: 1000000000

--- a/runner/clients/baserethnode/client.go
+++ b/runner/clients/baserethnode/client.go
@@ -276,3 +276,7 @@ func (r *BaseRethNodeClient) FlashblocksClient() types.FlashblocksClient {
 func (r *BaseRethNodeClient) SupportsFlashblocks() bool {
 	return true
 }
+
+func (r *BaseRethNodeClient) FlashblocksWsURL() string {
+	return ""
+}

--- a/runner/clients/builder/client.go
+++ b/runner/clients/builder/client.go
@@ -122,3 +122,11 @@ func (r *BuilderClient) FlashblocksClient() types.FlashblocksClient {
 func (r *BuilderClient) SupportsFlashblocks() bool {
 	return false
 }
+
+// FlashblocksWsURL returns the local WebSocket URL of the flashblocks server hosted by the builder.
+func (r *BuilderClient) FlashblocksWsURL() string {
+	if r.websocketPort == 0 {
+		return ""
+	}
+	return fmt.Sprintf("ws://localhost:%d", r.websocketPort)
+}

--- a/runner/clients/common/proxy/proxy.go
+++ b/runner/clients/common/proxy/proxy.go
@@ -89,12 +89,20 @@ func (p *ProxyServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var request struct {
+	// Detect JSON batch requests (arrays of RPC calls).
+	if len(body) > 0 && body[0] == '[' {
+		p.handleBatchRequest(w, body)
+		return
+	}
+
+	type rpcRequest struct {
 		Method  string          `json:"method"`
 		Params  json.RawMessage `json:"params"`
 		ID      interface{}     `json:"id"`
 		JSONRPC string          `json:"jsonrpc"`
 	}
+
+	var request rpcRequest
 
 	if err := json.Unmarshal(body, &request); err != nil {
 		http.Error(w, "Error parsing request", http.StatusBadRequest)
@@ -162,6 +170,48 @@ func (p *ProxyServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p.DebugResponse(request.Method, request.Params, respBody)
+}
+
+func (p *ProxyServer) handleBatchRequest(w http.ResponseWriter, body []byte) {
+	type rpcRequest struct {
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params"`
+		ID      interface{}     `json:"id"`
+		JSONRPC string          `json:"jsonrpc"`
+	}
+	var requests []rpcRequest
+	if err := json.Unmarshal(body, &requests); err != nil {
+		http.Error(w, "Error parsing batch request", http.StatusBadRequest)
+		return
+	}
+
+	type rpcResponse struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      interface{}     `json:"id"`
+		Result  json.RawMessage `json:"result,omitempty"`
+		Error   interface{}     `json:"error,omitempty"`
+	}
+
+	responses := make([]rpcResponse, 0, len(requests))
+	for _, req := range requests {
+		handled, result, err := p.OverrideRequest(req.Method, req.Params)
+		var resp rpcResponse
+		resp.JSONRPC = "2.0"
+		resp.ID = req.ID
+		if err != nil {
+			resp.Error = map[string]interface{}{"code": -32000, "message": err.Error()}
+		} else if handled {
+			resp.Result = result
+		} else {
+			resp.Error = map[string]interface{}{"code": -32601, "message": "method not supported in proxy batch mode"}
+		}
+		responses = append(responses, resp)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(responses); err != nil {
+		p.log.Error("Error encoding batch response", "err", err)
+	}
 }
 
 func (p *ProxyServer) OverrideRequest(method string, rawParams json.RawMessage) (bool, json.RawMessage, error) {

--- a/runner/clients/geth/client.go
+++ b/runner/clients/geth/client.go
@@ -280,3 +280,7 @@ func (g *GethClient) FlashblocksClient() types.FlashblocksClient {
 func (g *GethClient) SupportsFlashblocks() bool {
 	return false
 }
+
+func (g *GethClient) FlashblocksWsURL() string {
+	return ""
+}

--- a/runner/clients/reth/client.go
+++ b/runner/clients/reth/client.go
@@ -296,3 +296,7 @@ func (r *RethClient) FlashblocksClient() types.FlashblocksClient {
 func (r *RethClient) SupportsFlashblocks() bool {
 	return true
 }
+
+func (r *RethClient) FlashblocksWsURL() string {
+	return ""
+}

--- a/runner/clients/types/types.go
+++ b/runner/clients/types/types.go
@@ -30,4 +30,8 @@ type ExecutionClient interface {
 	SetHead(ctx context.Context, blockNumber uint64) error
 	FlashblocksClient() FlashblocksClient // returns nil for clients that don't support flashblocks
 	SupportsFlashblocks() bool            // returns true if the client supports receiving flashblock payloads
+	// FlashblocksWsURL returns the local WebSocket URL of the flashblocks server hosted by this
+	// client, or an empty string if the client does not host one. Used by the load-test worker to
+	// configure flashblocks_ws in the Rust load-tester binary.
+	FlashblocksWsURL() string
 }

--- a/runner/payload/factory.go
+++ b/runner/payload/factory.go
@@ -38,7 +38,7 @@ func NewPayloadWorker(ctx context.Context, log log.Logger, testConfig *benchtype
 			def = &loadtest.LoadTestPayloadDefinition{}
 		}
 		worker, err = loadtest.NewLoadTestPayloadWorker(
-			log, sequencerClient.ClientURL(), params, privateKey, amount, config, genesis.Config.ChainID, *def)
+			log, sequencerClient.ClientURL(), sequencerClient.FlashblocksWsURL(), params, privateKey, amount, config, genesis.Config.ChainID, *def)
 	case "transfer-only":
 		worker, err = transferonly.NewTransferPayloadWorker(
 			ctx, log, sequencerClient.ClientURL(), params, privateKey, amount, &genesis, definition.Params)

--- a/runner/payload/loadtest/load_test_worker.go
+++ b/runner/payload/loadtest/load_test_worker.go
@@ -32,34 +32,36 @@ type LoadTestPayloadDefinition struct {
 
 // loadTestConfig is the YAML config written to a temp file for the load-test binary.
 type loadTestConfig struct {
-	RPC           string    `yaml:"rpc"`
-	SenderCount   uint64    `yaml:"sender_count"`
-	TargetGPS     uint64    `yaml:"target_gps"`
-	Duration      string    `yaml:"duration"`
-	Seed          uint64    `yaml:"seed"`
-	FundingAmount string    `yaml:"funding_amount"`
-	Transactions  yaml.Node `yaml:"transactions"`
+	RPC             string    `yaml:"transaction_submission_rpcs"`
+	SetupRPC        string    `yaml:"setup_rpc,omitempty"`
+	FlashblocksWs   string    `yaml:"flashblocks_ws"`
+	SenderCount     uint64    `yaml:"sender_count"`
+	TargetGPS       uint64    `yaml:"target_gps"`
+	Duration        string    `yaml:"duration"`
+	Seed            uint64    `yaml:"seed"`
+	FundingAmount   string    `yaml:"funding_amount"`
+	Transactions    yaml.Node `yaml:"transactions"`
 }
 
 type loadTestPayloadWorker struct {
-	log            log.Logger
-	prefundSK      string
-	loadTestBin    string
-	elRPCURL       string
-	gasLimit       uint64
-	blockTimeSec   uint64
-	params         LoadTestPayloadDefinition
-	mempool        *mempool.StaticWorkloadMempool
-	proxyServer    *proxy.ProxyServer
-	cmd            *exec.Cmd
-	configFilePath string
+	log             log.Logger
+	prefundSK       string
+	loadTestBin     string
+	elRPCURL        string
+	flashblocksWsURL string
+	gasLimit        uint64
+	blockTimeSec    uint64
+	params          LoadTestPayloadDefinition
+	mempool         *mempool.StaticWorkloadMempool
+	proxyServer     *proxy.ProxyServer
+	cmd             *exec.Cmd
+	configFilePath  string
 }
 
-// NewLoadTestPayloadWorker creates a worker that runs the base-load-test binary
-// as an external transaction generator, capturing transactions via a proxy server.
 func NewLoadTestPayloadWorker(
 	log log.Logger,
 	elRPCURL string,
+	flashblocksWsURL string,
 	params types.RunParams,
 	prefundedPrivateKey ecdsa.PrivateKey,
 	prefundAmount *big.Int,
@@ -76,15 +78,16 @@ func NewLoadTestPayloadWorker(
 	}
 
 	w := &loadTestPayloadWorker{
-		log:          log,
-		prefundSK:    hex.EncodeToString(prefundedPrivateKey.D.Bytes()),
-		loadTestBin:  cfg.LoadTestBinary(),
-		elRPCURL:     elRPCURL,
-		gasLimit:     params.GasLimit,
-		blockTimeSec: blockTimeSec,
-		params:       definition,
-		mempool:      mp,
-		proxyServer:  ps,
+		log:              log,
+		prefundSK:        hex.EncodeToString(prefundedPrivateKey.D.Bytes()),
+		loadTestBin:      cfg.LoadTestBinary(),
+		elRPCURL:         elRPCURL,
+		flashblocksWsURL: flashblocksWsURL,
+		gasLimit:         params.GasLimit,
+		blockTimeSec:     blockTimeSec,
+		params:           definition,
+		mempool:          mp,
+		proxyServer:      ps,
 	}
 
 	return w, nil
@@ -206,8 +209,15 @@ func (w *loadTestPayloadWorker) writeConfig() (string, error) {
 		transactions = defaultTransactions()
 	}
 
+	flashblocksWs := w.flashblocksWsURL
+	if flashblocksWs == "" {
+		flashblocksWs = "ws://localhost:7111"
+	}
+
 	config := loadTestConfig{
 		RPC:           w.proxyServer.ClientURL(),
+		SetupRPC:      w.elRPCURL,
+		FlashblocksWs: flashblocksWs,
 		SenderCount:   senderCount,
 		TargetGPS:     targetGPS,
 		Duration:      "99999s",


### PR DESCRIPTION
## Summary

Three improvements to make the `load-test` payload type work correctly with the base-load-tester binary:

1. **Fix JSON-RPC batch request support in proxy** — the benchmark proxy was rejecting all batch `eth_sendRawTransaction` calls from the load-tester with HTTP 400, silently dropping all load-test transactions
2. **Wire `flashblocks_ws` URL into load-test config** — the load-tester requires a `flashblocks_ws` field but the benchmark never populated it, causing connection failures
3. **Add `setup_rpc` for Simulator contract deployment** — direct node URL so setup transactions bypass the proxy and land immediately
4. **Example config for simulator payload** — demonstrates the new `type: simulator` payload against the benchmark's `Simulator.sol` contract

## Changes

### `runner/clients/common/proxy/proxy.go` — batch RPC support

The load-tester's `BatchRpcClient` sends JSON arrays `[{...}, {...}]` per the JSON-RPC batch spec. The proxy was unmarshalling into a single struct and returning `HTTP 400` for all batch requests. Added `handleBatchRequest()` to parse the array and route each sub-request through `OverrideRequest()`, returning a matching array of responses.

**Impact**: without this fix, zero load-test transactions reach the sequencer despite the Rust binary appearing to submit them.

### `runner/clients/types/types.go` + all client implementations

Added `FlashblocksWsURL() string` to `ExecutionClient` interface:
- `BuilderClient`: returns `ws://localhost:<websocketPort>` (the builder's flashblocks server)
- `GethClient`, `RethClient`, `BaseRethNodeClient`: return `""` (no server)

### `runner/payload/loadtest/load_test_worker.go` + `factory.go`

- Populates `flashblocks_ws` in the generated load-tester YAML config using `sequencerClient.FlashblocksWsURL()`
- Adds `setup_rpc` field pointing to the direct sequencer RPC (not the proxy) so the load-tester can deploy the Simulator contract and initialize storage slots before the test run

### `configs/examples/load-test-simulator.yml`

Example benchmark config using `type: simulator` driven through the load-tester. Tested locally at 1280 simulator `run()` calls per block (~30.5M GPS).

## Local test results

```
numSuccess=1 numFailure=0

Block 10: txs=1281, gas=31,358,110, GPS=30,495,768
Block 13: txs=1281, gas=31,358,110, GPS=30,585,337  
Block 16: txs=1281, gas=31,358,110, GPS=30,633,922
Block 19: txs=1281, gas=31,358,110, GPS=30,532,355
```

## Related

- `base/base` PR: adds `type: simulator` to the load-tester and auto-deploys the Simulator contract