### PR TITLE
fix(report): handle empty load test block ranges

### DIFF
--- a/report/src/pages/LoadTestDetail.tsx
+++ b/report/src/pages/LoadTestDetail.tsx
@@ -91,6 +91,10 @@ const SummarySection = ({ result }: { result: LoadTestResult }) => {
   const submitted = result.throughput.total_submitted;
   const confirmed = result.throughput.total_confirmed;
   const failed = result.throughput.total_failed;
+  const blockRange = result.block_range;
+  const hasConfirmedBlockRange =
+    typeof blockRange?.first_block === "number" &&
+    typeof blockRange.last_block === "number";
 
   return (
     <StatCard title="Summary">
@@ -121,11 +125,15 @@ const SummarySection = ({ result }: { result: LoadTestResult }) => {
           value={formatEthFromWei(result.gas.total_cost_wei)}
           hint={`${result.gas.avg_gas_price.toLocaleString()} wei avg gas price`}
         />
-        {result.block_range && (
+        {blockRange && (
           <Stat
             label="Block range"
-            value={`${result.block_range.first_block.toLocaleString()} → ${result.block_range.last_block.toLocaleString()}`}
-            hint={`${result.block_range.block_count.toLocaleString()} blocks`}
+            value={
+              hasConfirmedBlockRange
+                ? `${blockRange.first_block.toLocaleString()} → ${blockRange.last_block.toLocaleString()}`
+                : "No confirmed transactions"
+            }
+            hint={`${blockRange.block_count.toLocaleString()} blocks`}
           />
         )}
       </StatGrid>

--- a/report/src/types.ts
+++ b/report/src/types.ts
@@ -168,8 +168,9 @@ export interface ThroughputPercentiles {
 }
 
 export interface BlockRange {
-  first_block: number;
-  last_block: number;
+  // Omitted when no test transactions were confirmed.
+  first_block?: number;
+  last_block?: number;
   block_count: number;
 }
 


### PR DESCRIPTION
## Summary
- Treat load-test `first_block` and `last_block` as optional because failed runs omit them.
- Render `No confirmed transactions` when a load-test result has no confirmed block range.

## Test plan
- `yarn check`
- `yarn test --run`
- `yarn build` with a local `output/.keep` placeholder for the existing static-copy target
