### PR TITLE
feat(runner): capture ClientVersion from EL binary and document report data contract

### DIFF
--- a/docs/report-data-contract.md
+++ b/docs/report-data-contract.md
@@ -1,0 +1,321 @@
+# Report data contract
+
+This document describes what the `report/` web UI in this repo expects
+from whatever produces benchmark data. The intent is to let `base/benchmark`
+become a **pure visualization tool** — any runner (Go, Rust, future
+monorepo) can produce data the report consumes, as long as it follows
+this contract.
+
+The current Go runner in `runner/` is one producer; the future Rust
+runner in the Coinbase monorepo will be another. Both write the same
+shape into the same S3 layout.
+
+## TL;DR
+
+- One S3 bucket. Under it: `metadata/` directory of small JSON files
+  describing runs, and `<outputDir>/` directories holding per-block
+  metrics for each run.
+- The report-api (`protocols/base-benchmarking/report-api`) merges all
+  `metadata/*.json` files into a single `GET /output/metadata.json`
+  response. The UI consumes that one response.
+- To add a benchmark run: drop one JSON file into `metadata/` and the
+  per-block metrics under its `outputDir`. No central file to update.
+- To compare across versions, time windows, or any other axis: write
+  the axis value into `testConfig` and the report-api groups
+  automatically.
+
+## S3 layout
+
+```
+s3://<bucket>/
+├── metadata/
+│   ├── metadata-<timestamp>.json        # one file per run group
+│   ├── metadata-<timestamp>.json
+│   └── ...
+└── <outputDir>/                         # one directory per inner run
+    ├── metrics-sequencer.json           # per-block sequencer metrics
+    ├── metrics-validator.json           # per-block validator metrics
+    └── metrics-<other-role>.json
+```
+
+### `metadata/` directory
+
+Every file is a **small JSON document** with this shape:
+
+```json
+{
+  "runs": [
+    {
+      "id": "test-1771965834150009",
+      "sourceFile": "./mainnet-config.yml",
+      "outputDir": "test-1771965834150009-1",
+      "testName": "Base Mainnet Performance Benchmark",
+      "testDescription": "...",
+      "testConfig": {
+        "BenchmarkRun": "test-1771965834150009",
+        "BlockTimeMilliseconds": 1000,
+        "GasLimit": 200000000,
+        "NodeType": "builder",
+        "TransactionPayload": "transfer-only",
+        "ClientVersion": "base-reth-node/v1.11.3-2ac58a2"
+      },
+      "result": {
+        "success": true,
+        "complete": true,
+        "clientVersion": "base-reth-node/v1.11.3-2ac58a2",
+        "sequencerMetrics": {
+          "gasPerSecond": 26090027.78,
+          "forkChoiceUpdated": 0.0022,
+          "getPayload": 0.0058,
+          "sendTxs": 0.24
+        },
+        "validatorMetrics": {
+          "gasPerSecond": 348413456.55,
+          "newPayload": 0.067
+        }
+      },
+      "thresholds": {
+        "warning": {"sequencer/latency/get_payload": 1000000000},
+        "error":   {"sequencer/latency/get_payload": 1500000000}
+      },
+      "createdAt": "2026-02-24T20:43:54.150038473Z",
+      "machineInfo": {
+        "type": "i7i.16xlarge",
+        "provider": "",
+        "region": "",
+        "fileSystem": "ext4"
+      }
+    }
+  ]
+}
+```
+
+The current Go runner writes **one file per run group**, where a "run
+group" is one execution of `base-bench run` and typically contains
+8–24 inner runs (one per payload × gas × node type variant). The
+report-api merges across files, so the contract permits any
+granularity — including one file per inner run (see "Future: one file
+per run" below).
+
+#### Required fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `runs[].id` | string | Unique run identifier. Used for deduplication. |
+| `runs[].outputDir` | string | Path under the bucket where per-block metrics live. |
+| `runs[].sourceFile` | string | Identifies the network. The report-api matches substrings (`mainnet`, `sepolia`, `testnet`, `devnet`) to scope comparison groups. |
+| `runs[].testName` | string | Human-readable name shown in the report UI dropdown. |
+| `runs[].testConfig.BenchmarkRun` | string | Cohort ID. All inner runs of one execution share this value. Drives the per-run page filter. |
+| `runs[].createdAt` | RFC3339 timestamp | Used for retention, sort order, and time-bucket comparisons. |
+
+Everything else is optional but recommended.
+
+#### `testConfig` is the filter/comparison driver
+
+The report's frontend **auto-discovers filter dropdowns** from any
+`testConfig` key that has >1 distinct value across the active run
+set. The report-api **auto-generates comparison groups** from
+`testConfig.ClientVersion`. Two implications:
+
+1. **Anything you want users to filter or compare on, write into
+   `testConfig`** — including custom dimensions like `region`, `build`,
+   `experiment`, `commit`.
+2. **Avoid putting volatile values in `testConfig`** (timestamps,
+   per-process state) — they'll create a dropdown entry per run and
+   make the UI useless.
+
+#### Standard `testConfig` keys
+
+| Key | Meaning | Notes |
+|---|---|---|
+| `BenchmarkRun` | Cohort ID | Required. |
+| `TransactionPayload` | Payload type | One per execution variant. |
+| `GasLimit` | Block gas limit | int. |
+| `BlockTimeMilliseconds` | Target block time | int. |
+| `NodeType` | EL flavor under test | e.g., `builder`, `reth`, `geth`, `base-reth-node`. |
+| `ClientVersion` | EL binary version | Format: `<name>/v<semver>-<7sha>`. The report-api groups by exact-match — pin it to a stable identifier per build. |
+| `ValidatorNodeType` | Validator EL flavor | Optional; defaults to `NodeType`. |
+
+You can add any other key. The UI handles them generically — no
+frontend change required.
+
+#### `ClientVersion` specifically
+
+Today the Go runner captures the version by probing `<bin> --version`
+after the EL starts up. The parser at
+`runner/clients/common/version.go::ParseRethVersionOutput` handles
+reth's multi-line format and returns `<version>-<7-char-sha>`.
+
+Producers in other languages should write the same shape:
+`<name>/v<semver>-<sha-prefix>`. Stable across rebuilds of the same
+commit; different across different commits. If `ClientVersion` is
+empty the run is silently excluded from version-comparison groups
+(it still appears under its own `BenchmarkRun` ID).
+
+The `BASE_BENCH_CLIENT_VERSION` env var beats the auto-detected
+value — deployment scripts can pin a human-readable label like
+`v1.2.3-rc1` instead of the raw build SHA.
+
+### `<outputDir>/` directories
+
+For each inner run, the runner writes per-block timeseries metrics
+under a directory whose name matches `runs[].outputDir`:
+
+```json
+[
+  {"BlockNumber": 1, "ExecutionMetrics": {"latency/get_payload": 4500000, ...}},
+  {"BlockNumber": 2, "ExecutionMetrics": {...}},
+  ...
+]
+```
+
+One file per role (`metrics-sequencer.json`, `metrics-validator.json`).
+The report-api serves them directly via
+`GET /output/<outputDir>/metrics-<role>.json` — no merging,
+no transformation. So the producer must write them in the final
+on-the-wire shape.
+
+The set of metric keys inside `ExecutionMetrics` is open. The
+frontend has a registry of "known" metrics with units and labels at
+`report/src/metricDefinitions.ts`; anything not listed there still
+renders, just with raw key names.
+
+## Comparison groups (automatic)
+
+The report-api automatically synthesizes two kinds of comparison
+"runs" alongside the natural ones:
+
+- **`[Compare: Time] <network> <testName>`** — picks the latest run
+  per variant per time bucket (`1d`/`1w`/`1m`).
+- **`[Compare: Versions] <network> <testName>`** — picks the latest
+  run per variant per distinct `ClientVersion`.
+
+These appear in the existing dropdown next to the natural
+`BenchmarkRun` IDs. Selecting one loads runs spanning the comparison
+dimension; the user picks `Show Line Per: ClientVersion` (or any
+other testConfig key) in the existing chart UI to overlay them as
+separate chart series.
+
+For these to populate:
+
+- **Time comparison** needs runs spanning ≥2 time buckets. Any
+  reasonable history satisfies this.
+- **Version comparison** needs runs with ≥2 distinct
+  `testConfig.ClientVersion` values. Empty/missing versions are
+  silently skipped.
+
+A cohort with fewer than 2 distinct buckets is dropped from the
+dropdown — a "comparison" of one thing isn't a comparison.
+
+## Producer responsibilities
+
+A new producer (Rust, monorepo, whatever) needs to:
+
+1. **Write one or more `metadata-<unique>.json` files** under
+   `s3://<bucket>/metadata/`. Filename only matters in that the
+   report-api lists everything ending in `.json` and processes it in
+   listing order (later writes deduplicate earlier ones on the
+   compound key `(id, outputDir)`).
+2. **Write per-block metrics** to
+   `s3://<bucket>/<outputDir>/metrics-<role>.json` for each
+   `runs[].outputDir`. Use the role names the report knows
+   (`sequencer`, `validator`) so the frontend's per-role panels
+   populate, or document the custom role somewhere the user can find
+   it.
+3. **Populate `testConfig.ClientVersion`** with a value distinct per
+   build. Without this, version-comparison groups can't form.
+4. **Populate `createdAt`** as RFC3339. Required for retention and
+   time-comparison.
+5. Optionally populate `thresholds`, `machineInfo`, `testDescription`
+   — improves the report UI but nothing breaks without them.
+
+That's the whole contract. No registration, no schema service, no
+central file to update.
+
+## Future: one file per run
+
+Today the Go runner writes one `metadata.json` per `base-bench run`
+execution containing all inner runs. The watcher uploads that whole
+file as one S3 object. This is a vestige of the runner's loop
+structure, not a contract requirement.
+
+Once we move to the Rust runner, the cleaner pattern is:
+
+- Each inner run emits its own tiny `metadata-<runID>.json` file
+  containing `{"runs": [<one run>]}`.
+- The watcher uploads each immediately on completion.
+- The report-api's merger already works exactly the same way — it
+  treats all `metadata-*.json` files as a flat input pool to dedupe
+  and sort.
+
+Two upgrades make this even cleaner:
+
+1. **Accept singular `{"run": {...}}`** in the merger alongside the
+   plural `{"runs": [...]}` form. Saves the producer from wrapping a
+   single run in a one-element array.
+2. **Stream uploads** as runs complete instead of batch-uploading at
+   the end. The current watcher already does this for the per-run
+   metrics files; extending it to the metadata file is the same
+   pattern.
+
+With those two changes, the runner becomes write-only and stateless:
+each inner run produces two S3 objects, then exits. The watcher
+becomes a thin S3 multipart-upload helper. The report-api stays as
+it is — no merger change needed.
+
+## Long-term: drop the merger
+
+A natural follow-on is to drop the merged `metadata.json` response
+entirely and serve per-run JSON via an index endpoint
+(`GET /api/v1/runs?since=<ts>` paginated). The frontend already has a
+data-source abstraction in
+`report/src/services/dataService.ts` — swapping out the metadata
+fetch would be a single function change. But this requires a
+frontend change, so it's a bigger lift than the producer-side
+upgrades above.
+
+The synthetic comparison groups in
+`report-api/internal/services/comparison.go` are a function of the
+full merged set, so dropping the merger means moving that synthesis
+into the index endpoint's result. The data shape (a flat list of
+runs, where some have synthetic IDs) stays identical from the
+frontend's perspective.
+
+## Frontend invariants (do not violate)
+
+The report frontend depends on these invariants. Violate one and the
+UI silently breaks.
+
+1. **One `outputDir` per inner run.** The UI fetches metrics by
+   `outputDir`; two runs sharing the same `outputDir` will fetch the
+   same metrics file and display identical chart series.
+2. **`BenchmarkRun` is a cohort key, not a run ID.** The per-run page
+   filters `allRuns.filter(r => r.testConfig.BenchmarkRun === selected)`.
+   Use `id` for per-run uniqueness; use `BenchmarkRun` to group runs
+   that should be shown together.
+3. **`testConfig` keys must be JSON-string-coercible.** The filter UI
+   does string comparison on the values. Don't put objects or arrays
+   there.
+4. **`testName` should be stable per series.** The report-api adds
+   prefixes for synthetic groups (`[Compare: …]`) and retention
+   monthly survivors (`[Monthly - Mon YYYY] …`); the synthesizer
+   strips these to canonicalize cohorts. If you add your own prefix
+   convention, document it here and update
+   `report-api/internal/services/comparison.go::canonicalTestName`
+   so cohorts don't fragment.
+
+## Pointers to code
+
+- Report-api S3 read path & merger:
+  `protocols/base-benchmarking/report-api/internal/services/s3.go`
+- Comparison synthesizer:
+  `protocols/base-benchmarking/report-api/internal/services/comparison.go`
+- Frontend types (what the UI expects):
+  `report/src/types.ts::BenchmarkRun`
+- Frontend metric definitions (keys/units/labels):
+  `report/src/metricDefinitions.ts`
+- Frontend filter logic (how dropdowns are auto-discovered):
+  `report/src/hooks/useBenchmarkFilters.ts` and `report/src/filter.ts`
+- Current Go runner that produces this shape:
+  `runner/benchmark/result_metadata.go::Run` and
+  `runner/service.go::applyClientVersion`

--- a/docs/report-data-contract.md
+++ b/docs/report-data-contract.md
@@ -12,17 +12,20 @@ shape into the same S3 layout.
 
 ## TL;DR
 
-- One S3 bucket. Under it: `metadata/` directory of small JSON files
-  describing runs, and `<outputDir>/` directories holding per-block
-  metrics for each run.
-- The report-api (`protocols/base-benchmarking/report-api`) merges all
-  `metadata/*.json` files into a single `GET /output/metadata.json`
-  response. The UI consumes that one response.
-- To add a benchmark run: drop one JSON file into `metadata/` and the
-  per-block metrics under its `outputDir`. No central file to update.
-- To compare across versions, time windows, or any other axis: write
-  the axis value into `testConfig` and the report-api groups
-  automatically.
+- One S3 bucket. Each run owns one prefix: `<outputDir>/metadata.json`
+  (run metadata) + `<outputDir>/metrics-<role>.json` (per-block
+  timeseries). No central file to update.
+- The report-api (`protocols/base-benchmarking/report-api`) lists all
+  top-level prefixes, reads the `metadata.json` under each, and merges
+  them into a single `GET /output/metadata.json` response. The UI
+  consumes that one response.
+- To add a benchmark run: upload metrics files first, then
+  `<outputDir>/metadata.json` last. The metadata file is the commit
+  signal — in-progress runs are invisible until it lands.
+- To compare across versions or time windows: write
+  `testConfig.ClientVersion` per build. The report-api synthesizes
+  `[Compare: Versions]` and `[Compare: Time]` groups automatically and
+  injects them into the same dropdown the user already uses.
 
 ## S3 layout
 
@@ -136,15 +139,16 @@ set. The report-api **auto-generates comparison groups** from
 
 #### Standard `testConfig` keys
 
-| Key | Meaning | Notes |
-|---|---|---|
-| `BenchmarkRun` | Cohort ID | Required. |
-| `TransactionPayload` | Payload type | One per execution variant. |
-| `GasLimit` | Block gas limit | int. |
-| `BlockTimeMilliseconds` | Target block time | int. |
-| `NodeType` | EL flavor under test | e.g., `builder`, `reth`, `geth`, `base-reth-node`. |
-| `ClientVersion` | EL binary version | Format: `<name>/v<semver>-<7sha>`. The report-api groups by exact-match — pin it to a stable identifier per build. |
-| `ValidatorNodeType` | Validator EL flavor | Optional; defaults to `NodeType`. |
+| Key | Source | Meaning | Notes |
+|---|---|---|---|
+| `BenchmarkRun` | Producer | Cohort ID | Required. All inner runs of one execution share this value. |
+| `TransactionPayload` | Producer | Payload type | One per execution variant. |
+| `GasLimit` | Producer | Block gas limit | int. |
+| `BlockTimeMilliseconds` | Producer | Target block time | int. |
+| `NodeType` | Producer | EL flavor under test | e.g., `builder`, `reth`, `geth`, `base-reth-node`. |
+| `ClientVersion` | Producer | EL binary version | Format: `<name>/v<semver>-<7sha>`. Report-api groups by exact-match — pin to a stable identifier per build. Drives `[Compare: Versions]`. |
+| `ValidatorNodeType` | Producer | Validator EL flavor | Optional; defaults to `NodeType`. |
+| `TimeBucket` | Report-api (synthetic only) | Which time window a comparison run came from | `1d`, `1w`, or `1m`. Only present on `[Compare: Time]` synthetic clones. Drives "Show Line Per: TimeBucket" in the chart UI. Never write this yourself — the report-api stamps it. |
 
 You can add any other key. The UI handles them generically — no
 frontend change required.
@@ -193,51 +197,68 @@ renders, just with raw key names.
 ## Comparison groups (automatic)
 
 The report-api automatically synthesizes two kinds of comparison
-"runs" alongside the natural ones:
+"runs" alongside the natural ones. No frontend change is needed —
+they appear in the existing dropdown, and the existing chart page
+renders them.
 
-- **`[Compare: Time] <network> <testName>`** — picks the latest run
-  per variant per time bucket (`1d`/`1w`/`1m`).
-- **`[Compare: Versions] <network> <testName>`** — picks the latest
-  run per variant per distinct `ClientVersion`.
+- **`[Compare: Time] <testName>`** — picks the most recent run
+  per variant per time window: `1d` (last 24h), `1w` (1–7 days
+  ago), `1m` (7–30 days ago). The report-api stamps
+  `testConfig.TimeBucket` (`"1d"` / `"1w"` / `"1m"`) on each clone
+  so the chart UI can split on it.
+- **`[Compare: Versions] <testName>`** — picks the most recent run
+  per variant per distinct `testConfig.ClientVersion`.
 
-These appear in the existing dropdown next to the natural
-`BenchmarkRun` IDs. Selecting one loads runs spanning the comparison
-dimension; the user picks `Show Line Per: ClientVersion` (or any
-other testConfig key) in the existing chart UI to overlay them as
-separate chart series.
+**How to use them in the UI:**
 
-For these to populate:
+1. Select a `[Compare: …]` entry from the run dropdown.
+2. On the chart comparison page, change `Show Line Per` to:
+   - **`TimeBucket`** for time comparisons (`1d` vs `1w` vs `1m`)
+   - **`ClientVersion`** for version comparisons
+3. The chart overlays one line per bucket/version per role.
 
-- **Time comparison** needs runs spanning ≥2 time buckets. Any
-  reasonable history satisfies this.
-- **Version comparison** needs runs with ≥2 distinct
-  `testConfig.ClientVersion` values. Empty/missing versions are
-  silently skipped.
+**When they appear:**
+
+- **Time comparison**: as soon as ≥2 of the three buckets have data
+  for a given `(testName, network)`. Any benchmark with a few weeks
+  of history qualifies immediately.
+- **Version comparison**: as soon as ≥2 distinct
+  `testConfig.ClientVersion` values exist for a given cohort.
+  Empty/missing versions are silently skipped. Requires the
+  `base/benchmark` runner change that populates `ClientVersion`.
 
 A cohort with fewer than 2 distinct buckets is dropped from the
-dropdown — a "comparison" of one thing isn't a comparison.
+dropdown — a comparison of one thing isn't a comparison.
+
+**Synthetic IDs are stable**: `compare-time-mainnet-base-mainnet-performance-benchmark-scale-base-over-150m-gas-limit`
+is the same `BenchmarkRun` ID across every metadata refresh, so URLs
+are bookmarkable.
+
+**Source runs are not modified**: synthetic entries are deep clones
+with rewritten `BenchmarkRun` and a `[Compare: …]` prefix on
+`testName`. The originals continue to appear under their natural IDs.
 
 ## Producer responsibilities
 
 A new producer (Rust, monorepo, whatever) needs to:
 
-1. **Write one or more `metadata-<unique>.json` files** under
-   `s3://<bucket>/metadata/`. Filename only matters in that the
-   report-api lists everything ending in `.json` and processes it in
-   listing order (later writes deduplicate earlier ones on the
-   compound key `(id, outputDir)`).
-2. **Write per-block metrics** to
-   `s3://<bucket>/<outputDir>/metrics-<role>.json` for each
-   `runs[].outputDir`. Use the role names the report knows
-   (`sequencer`, `validator`) so the frontend's per-role panels
-   populate, or document the custom role somewhere the user can find
-   it.
-3. **Populate `testConfig.ClientVersion`** with a value distinct per
-   build. Without this, version-comparison groups can't form.
-4. **Populate `createdAt`** as RFC3339. Required for retention and
-   time-comparison.
-5. Optionally populate `thresholds`, `machineInfo`, `testDescription`
-   — improves the report UI but nothing breaks without them.
+1. **Write metrics first**: upload
+   `s3://<bucket>/<outputDir>/metrics-<role>.json` for each role
+   (`sequencer`, `validator`). Use the canonical role names so the
+   frontend's per-role panels populate.
+2. **Write `metadata.json` last**: upload
+   `s3://<bucket>/<outputDir>/metadata.json` as the final step.
+   This is the **commit signal** — the run becomes visible to the
+   report-api only after this file lands. A run whose prefix exists
+   but has no `metadata.json` is silently ignored.
+3. **Populate `testConfig.ClientVersion`** with a stable per-build
+   identifier. Without this, `[Compare: Versions]` groups can't
+   form. Use `<name>/v<semver>-<7sha>` format.
+4. **Populate `createdAt`** as RFC3339. Required for retention,
+   sort order, and time-bucket comparisons.
+5. Optionally populate `thresholds`, `machineInfo`,
+   `testDescription` — improves the report UI but nothing breaks
+   without them.
 
 That's the whole contract. No registration, no schema service, no
 central file to update.

--- a/docs/report-data-contract.md
+++ b/docs/report-data-contract.md
@@ -28,17 +28,27 @@ shape into the same S3 layout.
 
 ```
 s3://<bucket>/
-├── metadata/
-│   ├── metadata-<timestamp>.json        # one file per run group
-│   ├── metadata-<timestamp>.json
-│   └── ...
 └── <outputDir>/                         # one directory per inner run
+    ├── metadata.json                    # this one run's metadata
     ├── metrics-sequencer.json           # per-block sequencer metrics
     ├── metrics-validator.json           # per-block validator metrics
     └── metrics-<other-role>.json
 ```
 
-### `metadata/` directory
+Each run owns one prefix. The presence of `metadata.json` under a
+prefix is the **commit signal**: the report-api treats a prefix
+without one as an in-progress (or aborted) run and ignores it. The
+producer must therefore upload metrics files first and `metadata.json`
+last.
+
+> **Legacy note**: prior to the per-run-directory cutover, the layout
+> was a central `metadata/metadata-<timestamp>.json` directory plus
+> `<outputDir>/` subdirectories. The report-api ignores anything
+> under the top-level `metadata/` prefix. The `backend migrate`
+> command splits any remaining legacy files into the new layout —
+> see the cutover runbook in the project NOTES.
+
+### `<outputDir>/metadata.json`
 
 Every file is a **small JSON document** with this shape:
 
@@ -90,12 +100,12 @@ Every file is a **small JSON document** with this shape:
 }
 ```
 
-The current Go runner writes **one file per run group**, where a "run
-group" is one execution of `base-bench run` and typically contains
-8–24 inner runs (one per payload × gas × node type variant). The
-report-api merges across files, so the contract permits any
-granularity — including one file per inner run (see "Future: one file
-per run" below).
+Every `<outputDir>/metadata.json` contains a **one-element `runs`
+array**. The plural shape is preserved for forward-compat — the
+report-api's parser accepts any length — but per-run files always
+write exactly one element. Producers must not pack multiple runs
+into one file in the new layout; that's a vestige of the legacy
+central-`metadata/` directory.
 
 #### Required fields
 
@@ -232,36 +242,30 @@ A new producer (Rust, monorepo, whatever) needs to:
 That's the whole contract. No registration, no schema service, no
 central file to update.
 
-## Future: one file per run
+## Migration from the legacy central-`metadata/` layout
 
-Today the Go runner writes one `metadata.json` per `base-bench run`
-execution containing all inner runs. The watcher uploads that whole
-file as one S3 object. This is a vestige of the runner's loop
-structure, not a contract requirement.
+Prior to the per-run cutover, the watcher uploaded the whole local
+`metadata.json` (containing N inner runs) to a central
+`metadata/metadata-<datetime>.json` directory on S3. The report-api
+listed every file in that directory, parsed each, and deduplicated
+runs by `(id, outputDir)`.
 
-Once we move to the Rust runner, the cleaner pattern is:
+The per-run-directory layout is strictly better:
 
-- Each inner run emits its own tiny `metadata-<runID>.json` file
-  containing `{"runs": [<one run>]}`.
-- The watcher uploads each immediately on completion.
-- The report-api's merger already works exactly the same way — it
-  treats all `metadata-*.json` files as a flat input pool to dedupe
-  and sort.
+- **Co-location**: each run's metadata sits next to its metrics
+  files. Deleting a run is one `aws s3 rm --recursive <outputDir>/`.
+- **Atomic commit**: the producer writes `metadata.json` last, so an
+  in-progress (or aborted) run is invisible until completion. No
+  half-written metadata can ever reach the report-api.
+- **Per-run isolation**: producers never write to a shared prefix.
+- **No central file to update**: critical for the Rust runner — each
+  inner run is a self-contained write-then-exit operation.
 
-Two upgrades make this even cleaner:
-
-1. **Accept singular `{"run": {...}}`** in the merger alongside the
-   plural `{"runs": [...]}` form. Saves the producer from wrapping a
-   single run in a one-element array.
-2. **Stream uploads** as runs complete instead of batch-uploading at
-   the end. The current watcher already does this for the per-run
-   metrics files; extending it to the metadata file is the same
-   pattern.
-
-With those two changes, the runner becomes write-only and stateless:
-each inner run produces two S3 objects, then exits. The watcher
-becomes a thin S3 multipart-upload helper. The report-api stays as
-it is — no merger change needed.
+The `backend migrate` command is a one-shot script that splits any
+remaining `metadata/metadata-*.json` files into per-run files and
+optionally removes the legacy directory. See the cutover runbook in
+the project NOTES for the exact sequence (pause the cron, run the
+migration, deploy, resume).
 
 ## Long-term: drop the merger
 

--- a/runner/clients/baserethnode/client.go
+++ b/runner/clients/baserethnode/client.go
@@ -224,29 +224,15 @@ func (r *BaseRethNodeClient) MetricsPort() int {
 	return int(r.metricsPort)
 }
 
-// GetVersion returns the version of the base-reth-node client
+// GetVersion returns the version of the base-reth-node client. See
+// common.ParseRethVersionOutput for the format contract.
 func (r *BaseRethNodeClient) GetVersion(ctx context.Context) (string, error) {
 	cmd := exec.CommandContext(ctx, r.options.BaseRethNodeBin, "--version")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get base-reth-node version")
 	}
-
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, "Version:") {
-			parts := strings.Split(line, "Version:")
-			if len(parts) >= 2 {
-				versionPart := strings.TrimSpace(parts[1])
-				versionFields := strings.Fields(versionPart)
-				if len(versionFields) > 0 {
-					return versionFields[0], nil
-				}
-			}
-		}
-	}
-	return "unknown", nil
+	return common.ParseRethVersionOutput(string(output)), nil
 }
 
 // SetHead resets the blockchain to a specific block using debug.setHead

--- a/runner/clients/common/version.go
+++ b/runner/clients/common/version.go
@@ -1,0 +1,73 @@
+package common
+
+import "strings"
+
+// ParseRethVersionOutput extracts a "<version>-<7-char-sha>" identifier
+// from the multi-line output emitted by `<reth-derivative> --version`.
+// Both base-reth-node and reth-optimism-cli share the upstream
+// reth-node-core build script, so the parser is hoisted here so the
+// per-client wrappers don't drift.
+//
+// Modern format (reth ≥ v1.11.x), one field per line:
+//
+//	reth 1.11.3
+//	Version: 1.11.3
+//	Commit SHA: 2ac58a25f561827e2b816a3c1ed972194f3b2915
+//	Build Timestamp: ...
+//	Build Features: ...
+//	Build Profile: maxperf
+//
+// Legacy single-line format (everything on one "Version: ... Commit
+// SHA: ..." line) is still supported for older binaries.
+//
+// Returns "unknown" if the output is unparseable. The "-<sha>" suffix
+// is dropped when no Commit SHA is present so the result remains
+// useful for legacy outputs that only carry a semver.
+//
+// Distinguishing two builds at the same semantic version is the
+// reason we capture the SHA at all — without it, the version-grouping
+// mode in the comparison report would collapse separate builds into
+// one bucket.
+func ParseRethVersionOutput(output string) string {
+	var version, sha string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if version == "" {
+			if v := extractFieldValue(line, "Version:"); v != "" {
+				version = strings.Fields(v)[0]
+			}
+		}
+		if sha == "" {
+			if s := extractFieldValue(line, "Commit SHA:"); s != "" {
+				short := strings.Fields(s)[0]
+				if len(short) > 7 {
+					short = short[:7]
+				}
+				sha = short
+			}
+		}
+		if version != "" && sha != "" {
+			break
+		}
+	}
+	switch {
+	case version != "" && sha != "":
+		return version + "-" + sha
+	case version != "":
+		return version
+	default:
+		return "unknown"
+	}
+}
+
+func extractFieldValue(line, key string) string {
+	idx := strings.Index(line, key)
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(line[idx+len(key):])
+	if rest == "" {
+		return ""
+	}
+	return rest
+}

--- a/runner/clients/common/version_test.go
+++ b/runner/clients/common/version_test.go
@@ -1,0 +1,55 @@
+package common
+
+import "testing"
+
+func TestParseRethVersionOutput_ModernMultiLine(t *testing.T) {
+	// Verbatim format from reth v1.11.4 (paradigmxyz/reth tag).
+	// Confirmed via librarian against the upstream build.rs at that tag.
+	out := `reth 1.11.3
+Version: 1.11.3
+Commit SHA: 2ac58a25f561827e2b816a3c1ed972194f3b2915
+Build Timestamp: 2026-05-01T12:00:00.000000000Z
+Build Features: jemalloc,asm-keccak
+Build Profile: maxperf
+`
+	got := ParseRethVersionOutput(out)
+	if got != "1.11.3-2ac58a2" {
+		t.Fatalf("got %q, want %q", got, "1.11.3-2ac58a2")
+	}
+}
+
+func TestParseRethVersionOutput_LegacySingleLine(t *testing.T) {
+	out := "reth-optimism-cli Version: 1.7.0 Commit SHA: 9d56da53ec0ad60e229456a0c70b338501d923a5 Build Timestamp: 2025-09-15 Build Profile: maxperf\n"
+	got := ParseRethVersionOutput(out)
+	if got != "1.7.0-9d56da5" {
+		t.Fatalf("got %q, want %q", got, "1.7.0-9d56da5")
+	}
+}
+
+func TestParseRethVersionOutput_NoSha(t *testing.T) {
+	out := "Version: 1.7.0\nBuild Profile: release\n"
+	if got := ParseRethVersionOutput(out); got != "1.7.0" {
+		t.Fatalf("got %q, want %q", got, "1.7.0")
+	}
+}
+
+func TestParseRethVersionOutput_Garbage(t *testing.T) {
+	out := "this is not a reth version string\nfoo bar\n"
+	if got := ParseRethVersionOutput(out); got != "unknown" {
+		t.Fatalf("got %q, want %q", got, "unknown")
+	}
+}
+
+func TestParseRethVersionOutput_ShortShaUnpadded(t *testing.T) {
+	// Defensive: SHA shorter than 7 chars must not panic the [:7] slice.
+	out := "Version: 1.0.0\nCommit SHA: abc\n"
+	if got := ParseRethVersionOutput(out); got != "1.0.0-abc" {
+		t.Fatalf("got %q, want %q", got, "1.0.0-abc")
+	}
+}
+
+func TestParseRethVersionOutput_Empty(t *testing.T) {
+	if got := ParseRethVersionOutput(""); got != "unknown" {
+		t.Fatalf("got %q, want %q", got, "unknown")
+	}
+}

--- a/runner/clients/reth/client.go
+++ b/runner/clients/reth/client.go
@@ -237,33 +237,15 @@ func (r *RethClient) MetricsPort() int {
 	return int(r.metricsPort)
 }
 
-// GetVersion returns the version of the Reth client
+// GetVersion returns the version of the Reth client. See
+// common.ParseRethVersionOutput for the format contract.
 func (r *RethClient) GetVersion(ctx context.Context) (string, error) {
 	cmd := exec.CommandContext(ctx, r.binPath, "--version")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get reth version")
 	}
-
-	// Parse version from output - reth version output has format like:
-	// reth-optimism-cli Version: 1.7.0 Commit SHA: 9d56da53ec0ad60e229456a0c70b338501d923a5 Build Timestamp: 2025-09-15T17:10:10.935613753Z Build Features: jemalloc Build Profile: maxperf
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, "Version:") {
-			// Extract just the version number after "Version:"
-			parts := strings.Split(line, "Version:")
-			if len(parts) >= 2 {
-				versionPart := strings.TrimSpace(parts[1])
-				// Get just the version number (before any space)
-				versionFields := strings.Fields(versionPart)
-				if len(versionFields) > 0 {
-					return versionFields[0], nil
-				}
-			}
-		}
-	}
-	return "unknown", nil
+	return common.ParseRethVersionOutput(string(output)), nil
 }
 
 // SetHead resets the blockchain to a specific block using debug.setHead

--- a/runner/network/network_benchmark.go
+++ b/runner/network/network_benchmark.go
@@ -40,6 +40,11 @@ type NetworkBenchmark struct {
 
 	collectedSequencerMetrics *benchtypes.SequencerKeyMetrics
 	collectedValidatorMetrics *benchtypes.ValidatorKeyMetrics
+	// collectedClientVersion is the EL binary version captured from
+	// the sequencer client (the EL under test). Best-effort: if the
+	// version probe fails we record an empty string and the caller
+	// falls back to operator overrides or marks the run unversioned.
+	collectedClientVersion string
 
 	testConfig  *benchtypes.TestConfig
 	proofConfig *benchmark.ProofProgramOptions
@@ -112,6 +117,15 @@ func (nb *NetworkBenchmark) benchmarkSequencer(ctx context.Context, l1Chain *l1C
 	sequencerClient, err := setupNode(ctx, nb.log, nb.testConfig.Params.NodeType, nb.testConfig.Params, nb.sequencerOptions, nb.ports, "", nb.flashblocksBlockTime)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("failed to setup sequencer node: %w", err)
+	}
+
+	// Capture the EL binary version. This is best-effort — version
+	// probing shells out to `<bin> --version`, so a binary that hangs
+	// or returns garbage shouldn't fail an otherwise-good benchmark.
+	if version, vErr := sequencerClient.GetVersion(ctx); vErr != nil {
+		nb.log.Warn("Failed to capture client version; comparison/version grouping will skip this run", "error", vErr)
+	} else {
+		nb.collectedClientVersion = version
 	}
 
 	// Create metrics collector and writer
@@ -268,6 +282,7 @@ func (nb *NetworkBenchmark) GetResult() (*benchmark.RunResult, error) {
 
 	result := &benchmark.RunResult{
 		SequencerMetrics: nb.collectedSequencerMetrics,
+		ClientVersion:    nb.collectedClientVersion,
 		Success:          true,
 		Complete:         true,
 	}

--- a/runner/service.go
+++ b/runner/service.go
@@ -637,6 +637,7 @@ outerLoop:
 			} else {
 				numSuccess++
 			}
+			applyClientVersion(&metadata.Runs[runIdx], metricSummary, os.Getenv("BASE_BENCH_CLIENT_VERSION"))
 			metadata.AddResult(runIdx, *metricSummary)
 
 			err = s.writeTestMetadata(metadata)
@@ -679,4 +680,27 @@ outerLoop:
 	}
 
 	return nil
+}
+
+// applyClientVersion stamps the client version onto a single run's
+// result + TestConfig before it is recorded into the metadata. The
+// envOverride parameter, when non-empty, takes precedence over the
+// auto-detected value from the EL binary — this lets deployment
+// scripts pin a human-readable label (e.g. "v1.2.3-rc1") even when
+// the binary's --version output is opaque or shared across CI
+// builds. Mutates both the run and the result in place. The mirror
+// into TestConfig exists so the report-api comparison endpoint and
+// the existing filter UI (which auto-discovers dropdowns from
+// testConfig keys) can both group on it.
+func applyClientVersion(run *benchmark.Run, result *benchmark.RunResult, envOverride string) {
+	if envOverride != "" {
+		result.ClientVersion = envOverride
+	}
+	if result.ClientVersion == "" {
+		return
+	}
+	if run.TestConfig == nil {
+		run.TestConfig = make(map[string]interface{})
+	}
+	run.TestConfig["ClientVersion"] = result.ClientVersion
 }

--- a/runner/service_test.go
+++ b/runner/service_test.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/base/base-bench/runner/benchmark"
+)
+
+func TestApplyClientVersion_AutoDetected(t *testing.T) {
+	run := &benchmark.Run{}
+	result := &benchmark.RunResult{ClientVersion: "reth/1.7.0"}
+	applyClientVersion(run, result, "")
+
+	if got := result.ClientVersion; got != "reth/1.7.0" {
+		t.Fatalf("result.ClientVersion=%q want %q", got, "reth/1.7.0")
+	}
+	if got := run.TestConfig["ClientVersion"]; got != "reth/1.7.0" {
+		t.Fatalf("TestConfig[ClientVersion]=%v want %q", got, "reth/1.7.0")
+	}
+}
+
+func TestApplyClientVersion_OverrideWins(t *testing.T) {
+	run := &benchmark.Run{}
+	result := &benchmark.RunResult{ClientVersion: "auto-detected"}
+	applyClientVersion(run, result, "v1.2.3-rc1")
+
+	if got := result.ClientVersion; got != "v1.2.3-rc1" {
+		t.Fatalf("override should win on result, got %q", got)
+	}
+	if got := run.TestConfig["ClientVersion"]; got != "v1.2.3-rc1" {
+		t.Fatalf("override should win in TestConfig, got %v", got)
+	}
+}
+
+func TestApplyClientVersion_OverrideFillsEmptyAuto(t *testing.T) {
+	run := &benchmark.Run{}
+	result := &benchmark.RunResult{}
+	applyClientVersion(run, result, "from-env")
+
+	if got := run.TestConfig["ClientVersion"]; got != "from-env" {
+		t.Fatalf("override should populate when auto-detect was empty, got %v", got)
+	}
+}
+
+func TestApplyClientVersion_NeitherSet(t *testing.T) {
+	run := &benchmark.Run{}
+	result := &benchmark.RunResult{}
+	applyClientVersion(run, result, "")
+
+	if run.TestConfig != nil {
+		t.Fatalf("TestConfig must not be allocated when no version is available, got %+v", run.TestConfig)
+	}
+	if result.ClientVersion != "" {
+		t.Fatalf("result.ClientVersion must stay empty, got %q", result.ClientVersion)
+	}
+}
+
+func TestApplyClientVersion_PreservesOtherTestConfigKeys(t *testing.T) {
+	run := &benchmark.Run{TestConfig: map[string]interface{}{"BenchmarkRun": "test-123", "GasLimit": 150_000_000}}
+	result := &benchmark.RunResult{ClientVersion: "reth/1.7.0"}
+	applyClientVersion(run, result, "")
+
+	if got := run.TestConfig["BenchmarkRun"]; got != "test-123" {
+		t.Errorf("pre-existing BenchmarkRun key should survive, got %v", got)
+	}
+	if got := run.TestConfig["GasLimit"]; got != 150_000_000 {
+		t.Errorf("pre-existing GasLimit key should survive, got %v", got)
+	}
+	if got := run.TestConfig["ClientVersion"]; got != "reth/1.7.0" {
+		t.Errorf("ClientVersion not stamped, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- **Capture `ClientVersion` from the EL binary** on every benchmark run and stamp it into both `RunResult.ClientVersion` and `Run.TestConfig["ClientVersion"]`. The existing `ExecutionClient.GetVersion(ctx)` interface method (which shells out to `<bin> --version`) was already declared and implemented per-client but never called. This PR calls it.
- **Shared version parser** at `runner/clients/common/version.go::ParseRethVersionOutput` replaces two divergent parsers in `clients/reth` and `clients/baserethnode` that were silently dropping the commit SHA. The new parser returns `<version>-<7-char-sha>` (e.g. `1.11.3-2ac58a2`). Without the SHA, two builds at the same semver collapse into one comparison bucket.
- **Operator override**: `BASE_BENCH_CLIENT_VERSION` env var beats the auto-detected value per-run, so deployment scripts can pin a human-readable label.
- **Best-effort**: a version probe failure logs a warning but the run still counts as successful.
- **`docs/report-data-contract.md`**: describes what the report UI (`report/`) expects from any producer — this Go runner today, a future Rust runner in the Coinbase monorepo. Covers the S3 per-run-directory layout, required/optional fields, `testConfig` as the filter/comparison driver (including the `TimeBucket` key that the server stamps on `[Compare: Time]` groups), `ClientVersion` format, frontend invariants, and the migration path.

## Why

The downstream `protocols/base-benchmarking` report-api can now group runs by `ClientVersion` and surface `[Compare: Versions]` views in the existing report UI dropdown. Without this commit, the field is always empty and version-comparison groups are silently dropped.

The SHA in the version string is the load-bearing piece: `1.11.3` alone can't distinguish two builds at the same release from different commits. `1.11.3-2ac58a2` can.

The doc captures the full data contract so the Rust monorepo migration doesn't have to reverse-engineer it from source. It describes the current per-run-directory S3 layout (not the legacy `metadata/` directory), the `TimeBucket` field (server-stamped, not producer-written), and step-by-step instructions for using both comparison group types.

## Tests

- `go test ./runner/...` — 11 new tests: 5 for `applyClientVersion` (env override, TestConfig stamping, precedence, no allocation when no version), 6 for `ParseRethVersionOutput` (modern multi-line, legacy single-line, no-sha, garbage, short-sha, empty). All pre-existing tests pass.
- `go vet ./runner/...` clean. `gofmt` clean.
- End-to-end verified via the companion `base-benchmarking` PR with 905MB of real production S3 data: `[Compare: Versions]` groups appear in the dropdown once two distinct `ClientVersion` values exist; `[Compare: Time]` works immediately on existing data.

## Deployment

Safe to merge independently. Until `BASE_BENCHMARK_COMMIT` is bumped in `protocols/base-benchmarking`'s `benchmark/versions.env`, this commit is a no-op for production. Once bumped, the next benchmark run starts writing `testConfig.ClientVersion`; the `[Compare: Versions]` entries in the report UI populate automatically — no further re-deploy needed.

type=routine
risk=low
impact=sev5
