### PR TITLE
fix: disable post-Jovian DA footprint cap in benchmark

### DIFF
--- a/runner/network/consensus/sequencer_consensus.go
+++ b/runner/network/consensus/sequencer_consensus.go
@@ -158,7 +158,11 @@ func (f *SequencerConsensusClient) generatePayloadAttributes(sequencerTxs [][]by
 		BlobBaseFeeScalar:    1,
 		OperatorFeeScalar:    0,
 		OperatorFeeConstant:  0,
-		DAFootprintGasScalar: 400,
+		// Intentionally 0: disables the post-Jovian DA footprint cap so
+		// the benchmark measures raw EL gas throughput rather than L1 DA
+		// budget. With a non-zero scalar, cheap-tx workloads plateau at
+		// ~50% of the configured gas limit regardless of EL capacity.
+		DAFootprintGasScalar: 0,
 	}
 
 	source := derive.L1InfoDepositSource{


### PR DESCRIPTION
## Problem

In the mainnet config benchmark (`Scale Base over 150M gas limit`), the `mainnet-transfer-only` and `mainnet-account-create-full-block` payloads plateau at exactly **52.6%** of the configured gas limit regardless of node capacity:

| Payload | 250M limit `gas/per_block` | Fill | Per-flashblock headroom |
|---|---|---|---|
| `storage-create-full-block` | 245 M | 98% | 0.9–1.9% |
| `mainnet-transfer-only` | 131 M | **52.6%** | **47.4% (every block)** |
| `mainnet-account-create-full-block` | 131 M | **52.6%** | **47.4% (every block)** |

(Run `test-1779411190779930`; the 47.4% headroom is identical across all 900 blocks and across all 150M/200M/250M gas limits, with a range of 0.10–0.36%.)

## Root cause

The Jovian DA-footprint cap in `base/crates/builder/core/src/execution.rs::is_tx_over_limits` was firing before the gas cap:

```rust
let tx_da_footprint = total_da_bytes_used.saturating_mul(da_footprint_gas_scalar as u64);
if tx_da_footprint > limits.block_da_footprint_limit.unwrap_or(limits.block_gas_limit) {
    return Err(TxnExecutionError::DAFootprintLimitExceeded { .. });
}
```

The benchmark hardcoded `DAFootprintGasScalar: 400`, and `block_da_footprint_limit` defaults to `block_gas_limit`. Effective rule:

```
cumulative_da_bytes × 400 ≤ block_gas_limit
→ max DA bytes/block = block_gas_limit / 400
```

For ~100 B-per-tx transferonly:

| Gas limit | Predicted tx/block (= limit / 400 / 100) | Observed tx/block |
|---|---|---|
| 150 M | 3,750 | **3,751** |
| 200 M | 5,000 | **5,000** |
| 250 M | 6,250 | **6,251** |

Variance < 0.03% across three limits — conclusive.

`storage-create-full-block` was unaffected because its txs are heavy in gas (~2.27 M) but light in DA (~200 B), so the gas cap fires first.

## Fix

Set `DAFootprintGasScalar` to `0` in `generatePayloadAttributes`. The check then computes `tx_da_footprint = bytes × 0 = 0 ≤ limit` and always passes. The scalar is serialized into the L1 attributes deposit tx and written to L2 state; the builder reads it via `fetch_da_footprint_gas_scalar` per block. Setup blocks (which run with `GasLimitSetup = 1e9`) propagate the new scalar before benchmark blocks start.

## Expected outcome on next rerun

- `mainnet-transfer-only @ 250M`: 131 M → ~245+ M `gas/per_block`
- `mainnet-account-create-full-block @ 250M`: was bound by both DA cap and EL speed (989 ms `get_payload`); will now be a true EL-limited measurement
- `storage-create-full-block @ 250M`: unchanged (~245 M, already gas-capped)
- `base-mainnet-simulation @ 250M`: still won't fill (separate worker-side scaleFactor bug, not addressed here)

## Verification

- `go build ./runner/...` clean
- `go vet ./runner/network/consensus/...` clean
- No tests in the consensus package exercise this code path
- Mechanism source-verified against `base/crates/builder/core/src/execution.rs`

## Rationale

The benchmark's question is "how much L2 gas/sec can the EL execute?". L1 DA capacity is a separate concern measured elsewhere; baking it into the gas-throughput benchmark masks the EL-throughput signal for cheap-tx workloads.

Draft because end-to-end validation requires a single ~12 h mainnet rerun.