### PR TITLE
fix(simulator): bump pre-init buffer 1.05x -> 2.0x to fix CI

### DIFF
--- a/runner/payload/simulator/worker.go
+++ b/runner/payload/simulator/worker.go
@@ -389,7 +389,11 @@ func (t *simulatorPayloadWorker) testForBlocks(ctx context.Context, simulator *a
 
 	t.log.Info("Calculated num calls per block", "numCalls", t.numCallsPerBlock, "gas", gas, "gasLimit", t.params.GasLimit, "buffer", buffer)
 
-	configForAllBlocks, err := t.payloadParams.Mul(float64(t.numCallsPerBlock) * float64(t.params.NumBlocks) * t.scaleFactor * 1.05).ToConfig()
+	// 2.0x safety multiplier (was 1.05). The 5% buffer was not enough to cover
+	// real on-chain consumption for base-mainnet-simulation @ 25M after PR #184,
+	// causing CI to revert with "Not enough accounts to load/update" mid-run.
+	// Pre-init is cheap relative to test runtime; err on the side of generous.
+	configForAllBlocks, err := t.payloadParams.Mul(float64(t.numCallsPerBlock) * float64(t.params.NumBlocks) * t.scaleFactor * 2.0).ToConfig()
 	if err != nil {
 		return errors.Wrap(err, "failed to convert payload params to config")
 	}


### PR DESCRIPTION
## Problem

The `basic-benchmarks` job in `.github/workflows/public-benchmarks.yaml` has been **failing on every push to main since 2026-05-15** (PR #184). Symptom:

```
execution reverted: Not enough accounts to load/update
```

Reproduces deterministically on `base-mainnet-simulation @ 25M gas` (the first matrix cell, run against both reth and geth), about 7-8 benchmark blocks into a 20-block run. CI history:

| Run | Date | Commit | Result |
|---|---|---|---|
| [26758739814](https://github.com/base/benchmark/actions/runs/26758739814) | 2026-06-01 | `b5290a8` (#191) | ❌ failure |
| [26655072445](https://github.com/base/benchmark/actions/runs/26655072445) | 2026-05-29 | `4f98307` (#186) | ❌ failure |
| [26525697996](https://github.com/base/benchmark/actions/runs/26525697996) | 2026-05-27 | (#188) | ❌ failure |
| ... | | | ❌ |
| [25935745254](https://github.com/base/benchmark/actions/runs/25935745254) | 2026-05-15 | `cf47296` (#184) | ❌ **first failure** |
| [25870299556](https://github.com/base/benchmark/actions/runs/25870299556) | 2026-05-14 | `cb5b9d6` | ✅ last green |

The contract revert is at [Simulator.sol:82](https://github.com/base/benchmark/blob/main/contracts/src/Simulator.sol#L82) — a benchmark-fidelity check that `current_address_index + load + update <= num_address_initialized`.

## Mechanism

PR #184 (`cf47296`) changed `targetCalls` in the simulator worker:

```diff
-targetCalls := uint64(math.Ceil(float64(t.numCallsPerBlock) * t.scaleFactor))
+targetCalls := t.numCallsPerBlock
```

This was correct for `scaleFactor > 1` (the 200M-gas case the PR was targeting). But for `scaleFactor < 1` (the 25M case from `base-mainnet-simulation`, where `scaleFactor = 25M / 35M = 0.714`), the change INCREASES per-block consumption from `ceil(46 × 0.714) = 33` calls/block to `46` calls/block.

Pre-init is sized as:
```go
configForAllBlocks = base × (numCallsPerBlock × NumBlocks × scaleFactor × 1.05)
```

This gives a uniform 5% buffer post-PR-#184. The buffer is **mathematically sufficient** for an ideal run, but in practice the boundary is too tight: rounding accumulation across multiple `Stats` fields (per-tx `blockCounts.Round()`, `big.Int.Int64()` truncation, etc.) plus the deterministic per-tx layout pushes consumption past the safety margin well before block 20.

## Fix

Bump the multiplier from `1.05` to `2.0`. Pre-init now allocates ~2× the predicted consumption. Pre-init runs during setup as a one-time cost (dominated by `mineAndConfirm` RPC batching), so the wall-clock impact is a few seconds per cell — negligible against the ~5 min/cell, ~1 h/job total runtime.

```diff
-configForAllBlocks, err := t.payloadParams.Mul(float64(t.numCallsPerBlock) * float64(t.params.NumBlocks) * t.scaleFactor * 1.05).ToConfig()
+// 2.0x safety multiplier (was 1.05). ...
+configForAllBlocks, err := t.payloadParams.Mul(float64(t.numCallsPerBlock) * float64(t.params.NumBlocks) * t.scaleFactor * 2.0).ToConfig()
```

## Verification

- `go build ./runner/...` clean
- `go vet ./runner/payload/simulator/...` clean
- `go test ./runner/payload/simulator/... -timeout 60s` clean (existing `mineAndConfirmBatchSize` tests pass; no test covers `testForBlocks` pre-init sizing directly)
- Mechanism is symmetric: only the SIZE of the pre-init batch changes, not what it does. Setup still runs `InitializeAddressChunk` / `InitializeStorageChunk` exactly the same way.

## Out of scope (follow-up)

While digging I noticed two real bugs worth separate PRs:

1. **`OpcodeStats.Sub`/`Add` iterate `other` rather than `s ∪ other`** ([types.go:48,38](https://github.com/base/benchmark/blob/main/runner/payload/simulator/simulatorstats/types.go)) → per-tx `blockCounts.Precompiles` is always empty in `sendTxs` → per-tx actual gas is much lower than the `gas` value `calcNumCalls` uses → block utilization is far below the configured gas limit even when the require passes.
2. **Self-recalibrating `numCallsPerBlock`** based on observed on-chain consumption would be more principled than the static safety multiplier and would also fix the `base-mainnet-simulation @ 250M` under-fill I documented in the gas-limit investigation. Likely a one-method addition to `simulatorPayloadWorker`.

Both are outside the scope of "make CI green again", which this PR does.

Draft because end-to-end validation requires one CI run.