### PR TITLE
fix(simulator): OpcodeStats Add/Sub must use union of keys

### DIFF
--- a/runner/payload/simulator/simulatorstats/types.go
+++ b/runner/payload/simulator/simulatorstats/types.go
@@ -27,9 +27,12 @@ func (o OpcodeStats) Round() OpcodeStats {
 }
 
 func (o OpcodeStats) Add(other OpcodeStats) OpcodeStats {
-	result := make(OpcodeStats)
+	result := make(OpcodeStats, len(o)+len(other))
+	for opcode, count := range o {
+		result[opcode] = count
+	}
 	for opcode, count := range other {
-		result[opcode] = o[opcode] + count
+		result[opcode] += count
 	}
 	return result
 }
@@ -43,9 +46,12 @@ func (o OpcodeStats) Pow(n float64) OpcodeStats {
 }
 
 func (o OpcodeStats) Sub(other OpcodeStats) OpcodeStats {
-	result := make(OpcodeStats)
+	result := make(OpcodeStats, len(o)+len(other))
+	for opcode, count := range o {
+		result[opcode] = count
+	}
 	for opcode, count := range other {
-		result[opcode] = o[opcode] - count
+		result[opcode] -= count
 	}
 	return result
 }

--- a/runner/payload/simulator/simulatorstats/types_test.go
+++ b/runner/payload/simulator/simulatorstats/types_test.go
@@ -1,0 +1,76 @@
+package simulatorstats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpcodeStatsAdd_UnionOfKeys(t *testing.T) {
+	a := OpcodeStats{"A": 1, "B": 2}
+	b := OpcodeStats{"B": 10, "C": 100}
+
+	got := a.Add(b)
+
+	require.Equal(t, 1.0, got["A"], "key only in receiver must be preserved")
+	require.Equal(t, 12.0, got["B"], "shared key must sum")
+	require.Equal(t, 100.0, got["C"], "key only in arg must be preserved")
+	require.Len(t, got, 3)
+}
+
+func TestOpcodeStatsAdd_EmptyOther(t *testing.T) {
+	a := OpcodeStats{"A": 1, "B": 2}
+	got := a.Add(OpcodeStats{})
+	require.Equal(t, 1.0, got["A"])
+	require.Equal(t, 2.0, got["B"])
+	require.Len(t, got, 2)
+}
+
+func TestOpcodeStatsAdd_EmptyReceiver(t *testing.T) {
+	got := OpcodeStats{}.Add(OpcodeStats{"A": 1, "B": 2})
+	require.Equal(t, 1.0, got["A"])
+	require.Equal(t, 2.0, got["B"])
+	require.Len(t, got, 2)
+}
+
+func TestOpcodeStatsSub_UnionOfKeys(t *testing.T) {
+	a := OpcodeStats{"A": 10, "B": 20}
+	b := OpcodeStats{"B": 5, "C": 100}
+
+	got := a.Sub(b)
+
+	require.Equal(t, 10.0, got["A"], "key only in receiver must be preserved")
+	require.Equal(t, 15.0, got["B"], "shared key must subtract")
+	require.Equal(t, -100.0, got["C"], "key only in arg must be included (negated)")
+	require.Len(t, got, 3)
+}
+
+func TestOpcodeStatsSub_EmptyOther(t *testing.T) {
+	a := OpcodeStats{"A": 10, "B": 20}
+	got := a.Sub(OpcodeStats{})
+	require.Equal(t, 10.0, got["A"])
+	require.Equal(t, 20.0, got["B"])
+	require.Len(t, got, 2)
+}
+
+func TestStatsSubAdd_FirstTxBlockCountsIncludePrecompiles(t *testing.T) {
+	base := &Stats{
+		Precompiles: OpcodeStats{"ecrecover": 0.5, "bls12381MapG2": 1.0},
+		Opcodes:     OpcodeStats{"KECCAK256": 10.0},
+	}
+
+	expected := base.Mul(1.0)
+	actual := NewStats()
+
+	blockCounts := expected.Sub(actual).Round()
+
+	require.Equal(t, 1.0, blockCounts.Precompiles["ecrecover"],
+		"precompiles missing in blockCounts means worker txs skip precompile execution")
+	require.Equal(t, 1.0, blockCounts.Precompiles["bls12381MapG2"])
+	require.Equal(t, 10.0, blockCounts.Opcodes["KECCAK256"])
+
+	actual = actual.Add(blockCounts)
+	require.Equal(t, 1.0, actual.Precompiles["ecrecover"],
+		"accumulated actual must remember the keys we added")
+	require.Equal(t, 1.0, actual.Precompiles["bls12381MapG2"])
+}


### PR DESCRIPTION
## Problem

`OpcodeStats.Add` and `OpcodeStats.Sub` (in `runner/payload/simulator/simulatorstats/types.go`) only iterate the **other** argument, silently dropping keys present in the receiver `o` but absent from `other`:

```go
func (o OpcodeStats) Add(other OpcodeStats) OpcodeStats {
    result := make(OpcodeStats)
    for opcode, count := range other {          // iterates 'other' only
        result[opcode] = o[opcode] + count
    }
    return result
}
```

Calling `OpcodeStats{"A": 1, "B": 2}.Add(OpcodeStats{})` returns `{}` — the receiver is gone.

## Downstream impact in `sendTxs`

The simulator worker accumulates per-tx config like:

```go
expected := t.payloadParams.Mul(float64(t.numCalls+1) * t.scaleFactor)  // has all base opcodes + precompiles
blockCounts := expected.Sub(actual).Round()                             // first tx: actual is empty
...
t.actualNumConfig = t.actualNumConfig.Add(blockCounts)
```

For the **first tx**, `actual` is empty. The buggy `Sub` iterates `actual` (empty) → produces `blockCounts` with **empty** `Opcodes`/`Precompiles` maps. Then `actual.Add(blockCounts)` likewise iterates `blockCounts` (now also empty for these fields) → still empty.

Result: every tx in every block has empty `Precompiles` in its `SimulatorConfig` call, so the on-chain `Run()` skips all precompile work that the YAML config specified.

## Observable consequence

Workloads with precompiles in their config — `base-mainnet-simulation` is the only one in `mainnet-config.yml` — under-fill the gas budget because per-tx gas is far below what `calcNumCalls` predicted from the gas-estimation call (which DID include precompiles). Concrete data from production run `test-1779411190779930`:

| Run | Payload | GasLimit | gas/per_block | Fill % |
|---|---|---|---|---|
| -0 | base-mainnet-simulation | 150 M | 49 M | 33% |
| -1 | base-mainnet-simulation | 200 M | 49 M | 24% |
| -2 | base-mainnet-simulation | 250 M | 51 M | **20%** |

Note the flat ~49–51 M ceiling regardless of GasLimit — that's the per-tx cost of the non-precompile portion (storage + accounts + opcodes) × 100 txs, which is what the worker actually executes. Other workloads (`storage-create-full-block`, etc.) don't declare precompiles in their config, so they're unaffected and fill ~98%.

## Fix

Both `Add` and `Sub` now iterate the union of keys:

```diff
 func (o OpcodeStats) Add(other OpcodeStats) OpcodeStats {
-    result := make(OpcodeStats)
+    result := make(OpcodeStats, len(o)+len(other))
+    for opcode, count := range o {
+        result[opcode] = count
+    }
     for opcode, count := range other {
-        result[opcode] = o[opcode] + count
+        result[opcode] += count
     }
     return result
 }
```

`Sub` matches: keys only in `other` produce negative entries (correct arithmetic semantics).

## Tests added

`runner/payload/simulator/simulatorstats/types_test.go`:

- `TestOpcodeStatsAdd_UnionOfKeys` / `TestOpcodeStatsSub_UnionOfKeys` — direct union-of-keys check
- `TestOpcodeStatsAdd_EmptyOther` / `TestOpcodeStatsAdd_EmptyReceiver` / `TestOpcodeStatsSub_EmptyOther` — empty-side edge cases
- `TestStatsSubAdd_FirstTxBlockCountsIncludePrecompiles` — regression test for the production usage pattern in `sendTxs`

All pass. `go test ./...` clean across the repo.

## Expected outcome after this PR + #192 land together

`base-mainnet-simulation` at 150M/200M/250M should fill to ~98% (gas budget becomes the cap, not the missing precompiles). Other workloads unchanged. The 1.05x→2.0x pre-init buffer in #192 covers the slightly higher consumption that comes from actually executing precompile work per tx.

Draft because end-to-end validation needs one CI run.