### PR TITLE
feat: show navbar immediately while metadata.json loads

### DIFF
--- a/report/src/components/Navbar.tsx
+++ b/report/src/components/Navbar.tsx
@@ -140,6 +140,9 @@ const Navbar = ({ urlPrefix }: ProvidedProps) => {
           </Link>
         </div>
       </div>
+      {!isLoadTestsRoute && isLoading && (
+        <div className="animate-pulse bg-slate-200 rounded-md h-8 w-48" />
+      )}
       {!isLoadTestsRoute && !isLoading && !!allBenchmarkRuns?.runs.length && (
         <div>
           <Select

--- a/report/src/pages/RunComparison.tsx
+++ b/report/src/pages/RunComparison.tsx
@@ -72,8 +72,16 @@ function RunComparison() {
     });
   }, [dataPerFile, selection.data]);
 
-  if (!benchmarkRuns || isLoadingBenchmarkRuns) {
-    return <div>Loading...</div>;
+  if (isLoadingBenchmarkRuns) {
+    return (
+      <div className="flex flex-col w-full min-h-screen">
+        <Navbar urlPrefix="/run-comparison" />
+        <div className="flex flex-col w-full flex-grow p-8 gap-4">
+          <div className="animate-pulse bg-slate-200 rounded h-6 w-48" />
+          <div className="animate-pulse bg-slate-100 rounded h-64 w-full" />
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/report/src/pages/RunIndex.tsx
+++ b/report/src/pages/RunIndex.tsx
@@ -177,8 +177,16 @@ const RunIndex = () => {
     };
   }, [allBenchmarkRuns, benchmarkRunId]);
 
-  if (!benchmarkRuns || isLoadingBenchmarkRuns) {
-    return <div>Loading...</div>;
+  if (isLoadingBenchmarkRuns) {
+    return (
+      <div className="flex flex-col w-full min-h-screen">
+        <Navbar />
+        <div className="flex flex-col w-full flex-grow p-8 gap-4">
+          <div className="animate-pulse bg-slate-200 rounded h-6 w-48" />
+          <div className="animate-pulse bg-slate-100 rounded h-64 w-full" />
+        </div>
+      </div>
+    );
   }
 
   return <RunIndexInner benchmarkRuns={benchmarkRuns} />;


### PR DESCRIPTION
## Summary

`metadata.json` can be slow to load. Previously the entire page render (including the navbar) was blocked behind the metadata fetch, showing just a bare `Loading...` div.

## Changes

**`Navbar.tsx`**: While `useTestMetadata()` is in-flight on benchmark routes, render an animated skeleton placeholder in the dropdown slot so the navbar is immediately visible and the layout doesn't shift when the select appears.

**`RunIndex.tsx`** / **`RunComparison.tsx`**: Replace the early-return `<div>Loading...</div>` with a full layout that renders `<Navbar />` plus skeleton content placeholders. The navbar now shows instantly while metadata loads.