### PR TITLE
fix(load-test): default to base-load-tester binary

### DIFF
--- a/benchmark/flags/flags.go
+++ b/benchmark/flags/flags.go
@@ -32,7 +32,7 @@ const (
 // TxFuzz defaults
 const (
 	DefaultTxFuzzBin   = "../tx-fuzz/cmd/livefuzzer/livefuzzer"
-	DefaultLoadTestBin = "./base-load-test"
+	DefaultLoadTestBin = "./base-load-tester"
 )
 
 var (

--- a/clients/build-base-reth-node.sh
+++ b/clients/build-base-reth-node.sh
@@ -43,9 +43,9 @@ echo "Checking out version: $BASE_RETH_NODE_VERSION"
 git checkout -f "$BASE_RETH_NODE_VERSION"
 
 # Build the binaries using cargo
-echo "Building base-reth-node, base-builder, and base-load-test with cargo..."
+echo "Building base-reth-node, base-builder, and base-load-tester with cargo..."
 cargo build --bin base-reth-node --bin base-builder --profile maxperf
-cargo build -p base-load-tests --bin base-load-test --profile maxperf
+cargo build -p base-load-tester-bin --bin base-load-tester --profile maxperf
 
 # Copy binaries to output directory
 echo "Copying binaries to output directory..."
@@ -74,10 +74,10 @@ else
     exit 1
 fi
 
-if [ -f "target/maxperf/base-load-test" ]; then
-    cp target/maxperf/base-load-test "$FINAL_OUTPUT_DIR/"
+if [ -f "target/maxperf/base-load-tester" ]; then
+    cp target/maxperf/base-load-tester "$FINAL_OUTPUT_DIR/"
 else
-    echo "No base-load-test binary found"
+    echo "No base-load-tester binary found"
     exit 1
 fi
 

--- a/configs/examples/load-test.yml
+++ b/configs/examples/load-test.yml
@@ -1,5 +1,5 @@
 name: Load test throughput test
-description: Test builder throughput using base-load-test binary as transaction generator
+description: Test builder throughput using base-load-tester binary as transaction generator
 payloads:
   - name: Load Test
     type: load-test

--- a/report/src/types.ts
+++ b/report/src/types.ts
@@ -113,7 +113,7 @@ export type BenchmarkRunWithStatus = BenchmarkRun & { status: RunStatus };
 // Load tests
 // -----------------------------------------------------------------------------
 //
-// These types mirror the JSON written by the `base-load-test` Rust binary and
+// These types mirror the JSON written by the `base-load-tester` Rust binary and
 // served by report-api at:
 //   GET /api/v1/load-tests/:network                  -> LoadTestEntry[]
 //   GET /api/v1/load-tests/:network/:timestamp       -> LoadTestResult

--- a/report/src/utils/formatters.tsx
+++ b/report/src/utils/formatters.tsx
@@ -189,7 +189,7 @@ const LOAD_TEST_TIMESTAMP_RE =
   /^(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})$/;
 
 export const parseLoadTestTimestamp = (raw: string): Date | null => {
-  // Format produced by base-load-test: "YYYY-MM-DD-HH-MM-SS" (UTC, no zone in
+  // Format produced by base-load-tester: "YYYY-MM-DD-HH-MM-SS" (UTC, no zone in
   // the string but the producer writes UTC). Returning null on parse failure
   // lets callers degrade to showing the raw string instead of crashing.
   const m = LOAD_TEST_TIMESTAMP_RE.exec(raw);

--- a/runner/payload/loadtest/load_test_worker.go
+++ b/runner/payload/loadtest/load_test_worker.go
@@ -52,7 +52,7 @@ type loadTestPayloadWorker struct {
 	outputPath         string
 }
 
-// NewLoadTestPayloadWorker creates a worker that runs the base-load-test binary
+// NewLoadTestPayloadWorker creates a worker that runs the base-load-tester binary
 // as an external transaction generator against the benchmark node's RPC.
 func NewLoadTestPayloadWorker(
 	log log.Logger,


### PR DESCRIPTION
## Summary

- update the load-test binary default from `./base-load-test` to `./base-load-tester`
- update the base client build helper to build/copy `base-load-tester` from `base-load-tester-bin`
- refresh stale comments and example text that referenced the old executable name

## Test

- `go test ./benchmark/... ./runner/payload/loadtest/... ./runner/config/...`

type=routine
risk=low
impact=sev5