### PR TITLE
feat(load-tests): label account-create reports and config overrides

### DIFF
--- a/report/src/components/ConfigCard.test.ts
+++ b/report/src/components/ConfigCard.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTransactions } from "./ConfigCard";
+
+describe("formatTransactions", () => {
+  it("formats a weighted transaction mix", () => {
+    expect(
+      formatTransactions({
+        transactions: [
+          { type: "uniswap_v3", weight: 50 },
+          { type: "aerodrome_cl", weight: 50 },
+        ],
+      }),
+    ).toBe("uniswap_v3 (50%) · aerodrome_cl (50%)");
+  });
+
+  it("labels full fresh-recipient transfers as account-create", () => {
+    expect(
+      formatTransactions({
+        fresh_recipient_ratio: 1,
+        transactions: [{ type: "transfer", weight: 100 }],
+      }),
+    ).toBe("account-create (100%)");
+  });
+
+  it("keeps partial fresh-recipient transfer ratios visible", () => {
+    expect(
+      formatTransactions({
+        fresh_recipient_ratio: 0.25,
+        transactions: [{ type: "transfer", weight: 100 }],
+      }),
+    ).toBe("transfer (100%, 25% account-create)");
+  });
+});

--- a/report/src/components/ConfigCard.tsx
+++ b/report/src/components/ConfigCard.tsx
@@ -11,12 +11,27 @@ interface Row {
   value: string;
 }
 
-const formatTransactions = (txs: LoadTestConfig["transactions"]): string => {
+const percent = (value: number): string => `${Math.round(value * 100)}%`;
+
+export const formatTransactions = (
+  config: Pick<LoadTestConfig, "transactions" | "fresh_recipient_ratio">,
+): string => {
+  const txs = config.transactions;
   if (!txs || txs.length === 0) return "—";
   const total = txs.reduce((acc, t) => acc + t.weight, 0);
   if (total === 0) return txs.map((t) => t.type).join(" · ");
+
+  const freshRecipientRatio = config.fresh_recipient_ratio ?? 0;
   return txs
-    .map((t) => `${t.type} (${Math.round((t.weight / total) * 100)}%)`)
+    .map((t) => {
+      if (t.type === "transfer" && freshRecipientRatio >= 1) {
+        return `account-create (${percent(t.weight / total)})`;
+      }
+      if (t.type === "transfer" && freshRecipientRatio > 0) {
+        return `${t.type} (${percent(t.weight / total)}, ${percent(freshRecipientRatio)} account-create)`;
+      }
+      return `${t.type} (${percent(t.weight / total)})`;
+    })
     .join(" · ");
 };
 
@@ -94,7 +109,7 @@ const RowGroup = ({ rows }: { rows: Row[] }) => (
 
 const ConfigCard = ({ config }: ConfigCardProps) => {
   const groups = buildRows(config);
-  const txLine = formatTransactions(config.transactions);
+  const txLine = formatTransactions(config);
 
   return (
     <StatCard title="Run config">

--- a/report/src/types.ts
+++ b/report/src/types.ts
@@ -209,6 +209,7 @@ export interface LoadTestConfig {
   seed: number;
   chain_id: number | null;
   transactions: Array<{ type: string; weight: number }>;
+  fresh_recipient_ratio?: number;
   looper_contract: string | null;
   swap_token_amount: string;
   // Producer omits unless real-token setup is enabled; loosely typed.

--- a/runner/benchmark/benchmark.go
+++ b/runner/benchmark/benchmark.go
@@ -46,17 +46,11 @@ func NewParamsFromValues(assignments map[string]interface{}) (*types.RunParams, 
 }
 
 func applyParam(params *types.RunParams, k string, v interface{}) error {
+	if k == "params" {
+		return applyParamGroup(params, v)
+	}
+
 	switch k {
-	case "params":
-		expanded, err := stringMap(v)
-		if err != nil {
-			return fmt.Errorf("invalid params %v", v)
-		}
-		for param, value := range expanded {
-			if err := applyParam(params, param, value); err != nil {
-				return err
-			}
-		}
 	case "payload":
 		if vPtrStr, ok := v.(*string); ok {
 			params.PayloadID = string(*vPtrStr)
@@ -90,7 +84,7 @@ func applyParam(params *types.RunParams, k string, v interface{}) error {
 			return fmt.Errorf("invalid gas limit %s", v)
 		}
 	case "load_test_config":
-		overrides, err := stringMap(v)
+		overrides, err := normalizeStringKeyMap(v)
 		if err != nil {
 			return fmt.Errorf("invalid load test config %v", v)
 		}
@@ -146,7 +140,22 @@ func applyParam(params *types.RunParams, k string, v interface{}) error {
 	return nil
 }
 
-func stringMap(value interface{}) (map[string]interface{}, error) {
+func applyParamGroup(params *types.RunParams, value interface{}) error {
+	// A params value groups multiple assignments into one matrix dimension,
+	// preserving relationships between values that should vary together.
+	expanded, err := normalizeStringKeyMap(value)
+	if err != nil {
+		return fmt.Errorf("invalid params %v", value)
+	}
+	for param, value := range expanded {
+		if err := applyParam(params, param, value); err != nil {
+			return fmt.Errorf("invalid params.%s: %w", param, err)
+		}
+	}
+	return nil
+}
+
+func normalizeStringKeyMap(value interface{}) (map[string]interface{}, error) {
 	switch typed := value.(type) {
 	case map[string]interface{}:
 		return typed, nil

--- a/runner/benchmark/benchmark.go
+++ b/runner/benchmark/benchmark.go
@@ -37,90 +37,132 @@ func NewParamsFromValues(assignments map[string]interface{}) (*types.RunParams, 
 	params := *DefaultParams
 
 	for k, v := range assignments {
-		switch k {
-		case "payload":
-			if vPtrStr, ok := v.(*string); ok {
-				params.PayloadID = string(*vPtrStr)
-			} else if vStr, ok := v.(string); ok {
-				params.PayloadID = string(vStr)
-			} else {
-				return nil, fmt.Errorf("invalid payload %s", v)
-			}
-		case "node_type":
-			if vStr, ok := v.(string); ok {
-				params.NodeType = vStr
-			} else {
-				return nil, fmt.Errorf("invalid node type %s", v)
-			}
-		case "client_bin":
-			if vStr, ok := v.(string); ok {
-				params.ClientBinPath = vStr
-			} else {
-				return nil, fmt.Errorf("invalid client bin %s", v)
-			}
-		case "validator_node_type":
-			if vStr, ok := v.(string); ok {
-				params.ValidatorNodeType = vStr
-			} else {
-				return nil, fmt.Errorf("invalid validator node type %s", v)
-			}
-		case "gas_limit":
-			if vInt, ok := v.(int); ok {
-				params.GasLimit = uint64(vInt)
-			} else {
-				return nil, fmt.Errorf("invalid gas limit %s", v)
-			}
-		case "consensus_timing":
-			if vStr, ok := v.(string); ok {
-				if vStr != "" && vStr != types.ConsensusTimingModePreventLateFCU && vStr != types.ConsensusTimingModeBaseConsensus {
-					return nil, fmt.Errorf("invalid consensus timing %s", v)
-				}
-				params.ConsensusTimingMode = vStr
-			} else {
-				return nil, fmt.Errorf("invalid consensus timing %s", v)
-			}
-		case "env":
-			if vStr, ok := v.(string); ok {
-				entries := strings.Split(vStr, ";")
-				params.Env = make(map[string]string)
-				for _, entry := range entries {
-					kv := strings.Split(entry, "=")
-					if len(kv) != 2 {
-						return nil, fmt.Errorf("invalid env entry %s", entry)
-					}
-					params.Env[kv[0]] = kv[1]
-				}
-			} else {
-				return nil, fmt.Errorf("invalid env %s", v)
-			}
-		case "num_blocks":
-			if vInt, ok := v.(int); ok {
-				params.NumBlocks = vInt
-			} else {
-				return nil, fmt.Errorf("invalid num blocks %s", v)
-			}
-		case "node_args":
-			// either a list of strings or a string (separated by spaces)
-			if vStr, ok := v.(string); ok {
-				params.NodeArgs = strings.Split(vStr, " ")
-			} else if vArr, ok := v.([]interface{}); ok {
-				// convert []interface{} to []string
-				nodeArgs := make([]string, len(vArr))
-				for i, arg := range vArr {
-					arg, ok := arg.(string)
-					if !ok {
-						return nil, fmt.Errorf("invalid non-string node arg %v", arg)
-					}
-					nodeArgs[i] = arg
-				}
-				params.NodeArgs = nodeArgs
-			} else {
-				return nil, fmt.Errorf("invalid node args %v", v)
-			}
+		if err := applyParam(&params, k, v); err != nil {
+			return nil, err
 		}
 	}
 
 	return &params, nil
+}
+
+func applyParam(params *types.RunParams, k string, v interface{}) error {
+	switch k {
+	case "params":
+		expanded, err := stringMap(v)
+		if err != nil {
+			return fmt.Errorf("invalid params %v", v)
+		}
+		for param, value := range expanded {
+			if err := applyParam(params, param, value); err != nil {
+				return err
+			}
+		}
+	case "payload":
+		if vPtrStr, ok := v.(*string); ok {
+			params.PayloadID = string(*vPtrStr)
+		} else if vStr, ok := v.(string); ok {
+			params.PayloadID = string(vStr)
+		} else {
+			return fmt.Errorf("invalid payload %s", v)
+		}
+	case "node_type":
+		if vStr, ok := v.(string); ok {
+			params.NodeType = vStr
+		} else {
+			return fmt.Errorf("invalid node type %s", v)
+		}
+	case "client_bin":
+		if vStr, ok := v.(string); ok {
+			params.ClientBinPath = vStr
+		} else {
+			return fmt.Errorf("invalid client bin %s", v)
+		}
+	case "validator_node_type":
+		if vStr, ok := v.(string); ok {
+			params.ValidatorNodeType = vStr
+		} else {
+			return fmt.Errorf("invalid validator node type %s", v)
+		}
+	case "gas_limit":
+		if vInt, ok := v.(int); ok {
+			params.GasLimit = uint64(vInt)
+		} else {
+			return fmt.Errorf("invalid gas limit %s", v)
+		}
+	case "load_test_config":
+		overrides, err := stringMap(v)
+		if err != nil {
+			return fmt.Errorf("invalid load test config %v", v)
+		}
+		params.LoadTestConfigOverrides = overrides
+	case "consensus_timing":
+		if vStr, ok := v.(string); ok {
+			if vStr != "" && vStr != types.ConsensusTimingModePreventLateFCU && vStr != types.ConsensusTimingModeBaseConsensus {
+				return fmt.Errorf("invalid consensus timing %s", v)
+			}
+			params.ConsensusTimingMode = vStr
+		} else {
+			return fmt.Errorf("invalid consensus timing %s", v)
+		}
+	case "env":
+		if vStr, ok := v.(string); ok {
+			entries := strings.Split(vStr, ";")
+			params.Env = make(map[string]string)
+			for _, entry := range entries {
+				kv := strings.Split(entry, "=")
+				if len(kv) != 2 {
+					return fmt.Errorf("invalid env entry %s", entry)
+				}
+				params.Env[kv[0]] = kv[1]
+			}
+		} else {
+			return fmt.Errorf("invalid env %s", v)
+		}
+	case "num_blocks":
+		if vInt, ok := v.(int); ok {
+			params.NumBlocks = vInt
+		} else {
+			return fmt.Errorf("invalid num blocks %s", v)
+		}
+	case "node_args":
+		// either a list of strings or a string (separated by spaces)
+		if vStr, ok := v.(string); ok {
+			params.NodeArgs = strings.Split(vStr, " ")
+		} else if vArr, ok := v.([]interface{}); ok {
+			// convert []interface{} to []string
+			nodeArgs := make([]string, len(vArr))
+			for i, arg := range vArr {
+				arg, ok := arg.(string)
+				if !ok {
+					return fmt.Errorf("invalid non-string node arg %v", arg)
+				}
+				nodeArgs[i] = arg
+			}
+			params.NodeArgs = nodeArgs
+		} else {
+			return fmt.Errorf("invalid node args %v", v)
+		}
+	}
+	return nil
+}
+
+func stringMap(value interface{}) (map[string]interface{}, error) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return typed, nil
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(typed))
+		for key, value := range typed {
+			keyString, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("non-string key %v", key)
+			}
+			out[keyString] = value
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("expected mapping")
+	}
 }
 
 const MAX_GAS_LIMIT = math.MaxUint64

--- a/runner/benchmark/matrix_test.go
+++ b/runner/benchmark/matrix_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/base/base-bench/runner/network/types"
 	"github.com/base/base-bench/runner/payload"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestResolveTestRunsFromMatrix(t *testing.T) {
@@ -89,6 +90,61 @@ func TestResolveTestRunsFromMatrix(t *testing.T) {
 						PayloadID:           "complex",
 						BlockTime:           1 * time.Second,
 						ConsensusTimingMode: types.ConsensusTimingModePreventLateFCU,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "combined params value",
+			config: benchmark.TestDefinition{
+				Variables: []benchmark.Param{
+					{
+						ParamType: "payload",
+						Value:     "load-test",
+					},
+					{
+						ParamType: "params",
+						Values: []interface{}{
+							map[string]interface{}{
+								"gas_limit": 400_000_000,
+								"load_test_config": map[string]interface{}{
+									"seed": 654_789,
+								},
+							},
+							map[string]interface{}{
+								"gas_limit": 800_000_000,
+								"load_test_config": map[string]interface{}{
+									"seed": 654_790,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []benchmark.TestRun{
+				{
+					Params: types.RunParams{
+						NodeType:            "geth",
+						GasLimit:            400_000_000,
+						PayloadID:           "load-test",
+						BlockTime:           1 * time.Second,
+						ConsensusTimingMode: types.ConsensusTimingModePreventLateFCU,
+						LoadTestConfigOverrides: map[string]interface{}{
+							"seed": 654_789,
+						},
+					},
+				},
+				{
+					Params: types.RunParams{
+						NodeType:            "geth",
+						GasLimit:            800_000_000,
+						PayloadID:           "load-test",
+						BlockTime:           1 * time.Second,
+						ConsensusTimingMode: types.ConsensusTimingModePreventLateFCU,
+						LoadTestConfigOverrides: map[string]interface{}{
+							"seed": 654_790,
+						},
 					},
 				},
 			},
@@ -365,6 +421,37 @@ func TestResolveTestRunsFromMatrixAllowsSnapshotLoadTestsToOverrideConsensusTimi
 	require.NoError(t, err)
 	require.Len(t, runs, 1)
 	require.Equal(t, types.ConsensusTimingModePreventLateFCU, runs[0].Params.ConsensusTimingMode)
+}
+
+func TestResolveTestRunsFromMatrixSupportsCombinedParamsFromYAML(t *testing.T) {
+	var config benchmark.BenchmarkConfig
+	require.NoError(t, yaml.Unmarshal([]byte(`
+name: snapshot account create
+block_time: 2s
+payloads:
+  - id: account-create
+    type: load-test
+benchmarks:
+  - variables:
+      - type: payload
+        value: account-create
+      - type: params
+        values:
+          - gas_limit: 400000000
+            load_test_config:
+              seed: 654789
+          - gas_limit: 800000000
+            load_test_config:
+              seed: 654790
+`), &config))
+
+	runs, err := benchmark.ResolveTestRunsFromMatrix(config.Benchmarks[0], "benchmark.yml", &config)
+	require.NoError(t, err)
+	require.Len(t, runs, 2)
+	require.Equal(t, uint64(400_000_000), runs[0].Params.GasLimit)
+	require.Equal(t, 654_789, runs[0].Params.LoadTestConfigOverrides["seed"])
+	require.Equal(t, uint64(800_000_000), runs[1].Params.GasLimit)
+	require.Equal(t, 654_790, runs[1].Params.LoadTestConfigOverrides["seed"])
 }
 
 func TestResolveTestRunsFromMatrixRejectsInvalidConsensusTiming(t *testing.T) {

--- a/runner/network/types/types.go
+++ b/runner/network/types/types.go
@@ -98,6 +98,10 @@ type RunParams struct {
 
 	// ClientBinPath is an optional override for the client binary path.
 	ClientBinPath string
+
+	// LoadTestConfigOverrides are YAML fields overlaid onto native base-load-tester
+	// config files for load-test payloads.
+	LoadTestConfigOverrides map[string]interface{}
 }
 
 const (
@@ -126,6 +130,9 @@ func (p RunParams) ToConfig() map[string]interface{} {
 
 	if p.ConsensusTimingMode != "" {
 		params["ConsensusTimingMode"] = p.ConsensusTimingMode
+	}
+	if len(p.LoadTestConfigOverrides) > 0 {
+		params["LoadTestConfigOverrides"] = p.LoadTestConfigOverrides
 	}
 
 	for k, v := range p.Tags {

--- a/runner/payload/loadtest/load_test_worker.go
+++ b/runner/payload/loadtest/load_test_worker.go
@@ -40,6 +40,7 @@ type loadTestPayloadWorker struct {
 	gasLimit           uint64
 	blockTime          time.Duration
 	params             LoadTestPayloadDefinition
+	configOverrides    map[string]interface{}
 	mempool            *mempool.StaticWorkloadMempool
 	cmd                *exec.Cmd
 	done               chan struct{}
@@ -82,6 +83,7 @@ func NewLoadTestPayloadWorker(
 		gasLimit:         params.GasLimit,
 		blockTime:        params.BlockTime,
 		params:           definition,
+		configOverrides:  params.LoadTestConfigOverrides,
 		mempool:          mp,
 		done:             make(chan struct{}),
 		sourceConfigPath: sourceConfigPath,
@@ -260,6 +262,13 @@ func (w *loadTestPayloadWorker) buildConfig() (*yaml.Node, error) {
 		targetGPS := w.gasLimit / uint64(w.blockTime.Seconds())
 		setMappingValue(config, "target_gps", uintNode(targetGPS))
 	}
+	for key, value := range w.configOverrides {
+		node, err := nodeFromValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid load-test config override %q: %w", key, err)
+		}
+		setMappingValue(config, key, node)
+	}
 
 	return config, nil
 }
@@ -295,6 +304,22 @@ func stringNode(value string) *yaml.Node {
 
 func uintNode(value uint64) *yaml.Node {
 	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.FormatUint(value, 10)}
+}
+
+func nodeFromValue(value interface{}) (*yaml.Node, error) {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	if len(doc.Content) == 0 {
+		return nil, errors.New("empty YAML value")
+	}
+	return doc.Content[0], nil
 }
 
 func stringSequenceNode(values ...string) *yaml.Node {

--- a/runner/payload/loadtest/load_test_worker_test.go
+++ b/runner/payload/loadtest/load_test_worker_test.go
@@ -143,6 +143,47 @@ transactions:
 	require.Contains(t, output, "duration: \"60s\"")
 }
 
+func TestBuildConfigAppliesLoadTestConfigOverrides(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "load-test.yaml")
+	err := os.WriteFile(configPath, []byte(`
+transaction_submission_rpcs:
+  - "http://standalone-submitter.invalid"
+query_rpc: "http://standalone-query.invalid"
+flashblocks_ws: "ws://standalone-flashblocks.invalid"
+target_gps: 123
+seed: 654789
+duration: "60s"
+transactions:
+  - weight: 100
+    type: transfer
+`), 0644)
+	require.NoError(t, err)
+
+	worker := &loadTestPayloadWorker{
+		flashblocksURL:   "ws://benchmark-flashblocks.example",
+		gasLimit:         150_000_000,
+		blockTime:        2 * time.Second,
+		elRPCURL:         "http://sequencer.example",
+		sourceConfigPath: configPath,
+		configOverrides: map[string]interface{}{
+			"seed":                  654_790,
+			"fresh_recipient_ratio": 1.0,
+		},
+	}
+
+	config, err := worker.buildConfig()
+	require.NoError(t, err)
+
+	encoded, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	output := string(encoded)
+
+	require.Contains(t, output, "target_gps: 75000000")
+	require.Contains(t, output, "seed: 654790")
+	require.Contains(t, output, "fresh_recipient_ratio: 1")
+	require.NotContains(t, output, "seed: 654789")
+}
+
 func TestSetupPreparesConfigWithoutStartingProcess(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "load-test.yaml")
 	err := os.WriteFile(configPath, []byte(`


### PR DESCRIPTION
## Summary
- label transfer-only fresh-recipient load tests as account-create in the report workload row
- keep partial fresh-recipient ratios visible in the transaction mix label
- add matrix-row `load_test_config` overrides for native base-load-tester configs
- add coverage for transaction workload formatting, combined matrix params, YAML-shaped params, and load-test config overrides

## Test plan
- `corepack yarn test --run`
- `corepack yarn eslint src/components/ConfigCard.tsx src/components/ConfigCard.test.ts src/types.ts`
- `go test ./runner/benchmark ./runner/payload/loadtest ./runner/network/types`

## Notes
- `corepack yarn tsc --noEmit` still fails on existing test/page type errors unrelated to this change.

### Change Management
type=routine<!--{routine,nonroutine,emergency}-->
risk=low<!--{low,medium,high}-->
impact=sev5<!--{sev1,sev2,sev3,sev4,sev5}-->
automerge=false
